### PR TITLE
Amend AlternateIdentifier

### DIFF
--- a/schema.rst
+++ b/schema.rst
@@ -1,114 +1,126 @@
 Metadata Schema for the Persistent Identification of Scientific Measuring Instruments
 =====================================================================================
 
-+-------+----------------------------+------------+-----+------------------------+------------------------+
-| ID    | Property                   | Obligation | Occ | Definition             | Allowed values,        |
-|       |                            |            |     |                        | constraints,           |
-|       |                            |            |     |                        | remarks                |
-+-------+----------------------------+------------+-----+------------------------+------------------------+
-| 1     | Identifier                 | M          | 1   | Unique string that     | PIDINST                |
-|       |                            |            |     | identifies the         |                        |
-|       |                            |            |     | instrument instance    |                        |
-+-------+----------------------------+------------+-----+------------------------+------------------------+
-| 1.1   | identifierType             | M          | 1   | Type of the identifier | Controlled list        |
-|       |                            |            |     |                        | of values:             |
-|       |                            |            |     |                        |   PIDINST              |
-+-------+----------------------------+------------+-----+------------------------+------------------------+
-| 2     | LandingPage                | M          | 1   | A landing page that    | URL                    |
-|       |                            |            |     | the identifier         |                        |
-|       |                            |            |     | resolves to            |                        |
-|       |                            |            |     |                        |                        |
-|       |                            |            |     |                        |                        |
-+-------+----------------------------+------------+-----+------------------------+------------------------+
-| 3     | Name                       | M          | 1   | Name by which the      | Free text              |
-|       |                            |            |     | instrument instance is |                        |
-|       |                            |            |     | known                  |                        |
-+-------+----------------------------+------------+-----+------------------------+------------------------+
-| 4     | Owner                      | M          | 1-n | Institution(s)         |                        |
-|       |                            |            |     | responsible for the    |                        |
-|       |                            |            |     | management of the      |                        |
-|       |                            |            |     | instrument. This may   |                        |
-|       |                            |            |     | include the legal      |                        |
-|       |                            |            |     | owner, the operator,   |                        |
-|       |                            |            |     | or an institute        |                        |
-|       |                            |            |     | providing access to    |                        |
-|       |                            |            |     | the instrument.        |                        |
-+-------+----------------------------+------------+-----+------------------------+------------------------+
-| 4.1   | ownerName                  | M          | 1   | Full name of the owner | Free text              |
-+-------+----------------------------+------------+-----+------------------------+------------------------+
-| 4.2   | ownerContact               | O          | 0-1 | Contact address of the | Electronic mail        |
-|       |                            |            |     | owner                  | address                |
-|       |                            |            |     |                        |                        |
-+-------+----------------------------+------------+-----+------------------------+------------------------+
-| 4.3   | ownerIdentifier            | O          | 0-1 | Persistent identifier  | Free text, must be     |
-|       |                            |            |     | of the owner           | globally unique        |
-|       |                            |            |     |                        | identifiers.           |
-+-------+----------------------------+------------+-----+------------------------+------------------------+
-| 4.3.1 | ownerIdentifierType        | O          | 1   | Type of the identifier | Free text              |
-+-------+----------------------------+------------+-----+------------------------+------------------------+
-| 5     | Manufacturer               | M          | 1-n | The instrument's       |                        |
-|       |                            |            |     | manufacturer(s) or     |                        |
-|       |                            |            |     | developer. This may    |                        |
-|       |                            |            |     | also be the owner for  |                        |
-|       |                            |            |     | custom build           |                        |
-|       |                            |            |     | instruments            |                        |
-+-------+----------------------------+------------+-----+------------------------+------------------------+
-| 5.1   | manufacturerName           | M          | 1   | Full name of the       | Free text              |
-|       |                            |            |     | manufacturer           |                        |
-+-------+----------------------------+------------+-----+------------------------+------------------------+
-| 5.2   | manufacturerIdentifier     | O          | 0-1 | Persistent identifier  | Free text, must be     |
-|       |                            |            |     | of the manufacturer    | globally unique        |
-|       |                            |            |     |                        | identifiers.           |
-+-------+----------------------------+------------+-----+------------------------+------------------------+
-| 5.2.1 | manufacturerIdentifierType | O          | 1   | Type of the identifier | Free text              |
-+-------+----------------------------+------------+-----+------------------------+------------------------+
-| 6     | Description                | R          | 0-1 | Technical description  | Free text              |
-|       |                            |            |     | of the device and its  |                        |
-|       |                            |            |     | capabilities           |                        |
-+-------+----------------------------+------------+-----+------------------------+------------------------+
-| 7     | InstrumentType             | R          | 0-1 | Classification of the  | Free text              |
-|       |                            |            |     | type of the instrument |                        |
-+-------+----------------------------+------------+-----+------------------------+------------------------+
-| 8     | VariableMeasured           | R          | 0-n | The variable(s) that   | Free text              |
-|       |                            |            |     | this instrument        |                        |
-|       |                            |            |     | measures or observes   |                        |
-+-------+----------------------------+------------+-----+------------------------+------------------------+
-| 9     | Date                       | R          | 0-n | Dates relevant to the  | ISO 8601               |
-|       |                            |            |     | instrument             |                        |
-+-------+----------------------------+------------+-----+------------------------+------------------------+
-| 9.1   | dateType                   | R          | 1   | The type of the date   | Controlled list        |
-|       |                            |            |     |                        | of values:             |
-|       |                            |            |     |                        |   Commissioned,        |
-|       |                            |            |     |                        |   DeCommissioned,      |
-|       |                            |            |     |                        |   ...                  |
-+-------+----------------------------+------------+-----+------------------------+------------------------+
-| 10    | RelatedIdentifier          | R          | 0-n | Identifiers of related | Free text, must be     |
-|       |                            |            |     | resources              | globally unique        |
-|       |                            |            |     |                        | identifiers.           |
-+-------+----------------------------+------------+-----+------------------------+------------------------+
-| 10.1  | relatedIdentifierType      | R          | 1   | Type of the identifier | Controlled list        |
-|       |                            |            |     |                        | of values:             |
-|       |                            |            |     |                        |   PIDINST, DOI,        |
-|       |                            |            |     |                        |   Handle, URL,         |
-|       |                            |            |     |                        |   URN, ...             |
-+-------+----------------------------+------------+-----+------------------------+------------------------+
-| 10.2  | relationType               | R          | 1   | Description of the     | Controlled list        |
-|       |                            |            |     | relationship           | of values:             |
-|       |                            |            |     |                        |   IsDescribedBy,       |
-|       |                            |            |     |                        |   IsNewVersionOf,      |
-|       |                            |            |     |                        |   IsPreviousVersionOf, |
-|       |                            |            |     |                        |   HasComponent,        |
-|       |                            |            |     |                        |   IsComponentOf,       |
-|       |                            |            |     |                        |   References,          |
-|       |                            |            |     |                        |   HasMetadata, ...     |
-+-------+----------------------------+------------+-----+------------------------+------------------------+
-| 11    | AlternateIdentifier        | O          | 0-n | Identifiers other than | Free text, should be   |
-|       |                            |            |     | the PIDINST pertaining | unique identifiers     |
-|       |                            |            |     | to the same instrument |                        |
-|       |                            |            |     | instance               |                        |
-+-------+----------------------------+------------+-----+------------------------+------------------------+
-| 11.1  | alternateIdentifierType    | O          | 1   | Type of the identifier | Free text              |
-+-------+----------------------------+------------+-----+------------------------+------------------------+
++-------+----------------------------+------------+-----+--------------------------+------------------------+
+| ID    | Property                   | Obligation | Occ | Definition               | Allowed values,        |
+|       |                            |            |     |                          | constraints,           |
+|       |                            |            |     |                          | remarks                |
++-------+----------------------------+------------+-----+--------------------------+------------------------+
+| 1     | Identifier                 | M          | 1   | Unique string that       | PIDINST                |
+|       |                            |            |     | identifies the           |                        |
+|       |                            |            |     | instrument instance      |                        |
++-------+----------------------------+------------+-----+--------------------------+------------------------+
+| 1.1   | identifierType             | M          | 1   | Type of the identifier   | Controlled list        |
+|       |                            |            |     |                          | of values:             |
+|       |                            |            |     |                          |   PIDINST              |
++-------+----------------------------+------------+-----+--------------------------+------------------------+
+| 2     | LandingPage                | M          | 1   | A landing page that      | URL                    |
+|       |                            |            |     | the identifier           |                        |
+|       |                            |            |     | resolves to              |                        |
+|       |                            |            |     |                          |                        |
+|       |                            |            |     |                          |                        |
++-------+----------------------------+------------+-----+--------------------------+------------------------+
+| 3     | Name                       | M          | 1   | Name by which the        | Free text              |
+|       |                            |            |     | instrument instance is   |                        |
+|       |                            |            |     | known                    |                        |
++-------+----------------------------+------------+-----+--------------------------+------------------------+
+| 4     | Owner                      | M          | 1-n | Institution(s)           |                        |
+|       |                            |            |     | responsible for the      |                        |
+|       |                            |            |     | management of the        |                        |
+|       |                            |            |     | instrument. This may     |                        |
+|       |                            |            |     | include the legal        |                        |
+|       |                            |            |     | owner, the operator,     |                        |
+|       |                            |            |     | or an institute          |                        |
+|       |                            |            |     | providing access to      |                        |
+|       |                            |            |     | the instrument.          |                        |
++-------+----------------------------+------------+-----+--------------------------+------------------------+
+| 4.1   | ownerName                  | M          | 1   | Full name of the owner   | Free text              |
++-------+----------------------------+------------+-----+--------------------------+------------------------+
+| 4.2   | ownerContact               | O          | 0-1 | Contact address of the   | Electronic mail        |
+|       |                            |            |     | owner                    | address                |
+|       |                            |            |     |                          |                        |
++-------+----------------------------+------------+-----+--------------------------+------------------------+
+| 4.3   | ownerIdentifier            | O          | 0-1 | Persistent identifier    | Free text, must be     |
+|       |                            |            |     | of the owner             | globally unique        |
+|       |                            |            |     |                          | identifiers.           |
++-------+----------------------------+------------+-----+--------------------------+------------------------+
+| 4.3.1 | ownerIdentifierType        | O          | 1   | Type of the identifier   | Free text              |
++-------+----------------------------+------------+-----+--------------------------+------------------------+
+| 5     | Manufacturer               | M          | 1-n | The instrument's         |                        |
+|       |                            |            |     | manufacturer(s) or       |                        |
+|       |                            |            |     | developer. This may      |                        |
+|       |                            |            |     | also be the owner for    |                        |
+|       |                            |            |     | custom build             |                        |
+|       |                            |            |     | instruments              |                        |
++-------+----------------------------+------------+-----+--------------------------+------------------------+
+| 5.1   | manufacturerName           | M          | 1   | Full name of the         | Free text              |
+|       |                            |            |     | manufacturer             |                        |
++-------+----------------------------+------------+-----+--------------------------+------------------------+
+| 5.2   | manufacturerIdentifier     | O          | 0-1 | Persistent identifier    | Free text, must be     |
+|       |                            |            |     | of the manufacturer      | globally unique        |
+|       |                            |            |     |                          | identifiers.           |
++-------+----------------------------+------------+-----+--------------------------+------------------------+
+| 5.2.1 | manufacturerIdentifierType | O          | 1   | Type of the identifier   | Free text              |
++-------+----------------------------+------------+-----+--------------------------+------------------------+
+| 6     | Description                | R          | 0-1 | Technical description    | Free text              |
+|       |                            |            |     | of the device and its    |                        |
+|       |                            |            |     | capabilities             |                        |
++-------+----------------------------+------------+-----+--------------------------+------------------------+
+| 7     | InstrumentType             | R          | 0-1 | Classification of the    | Free text              |
+|       |                            |            |     | type of the instrument   |                        |
++-------+----------------------------+------------+-----+--------------------------+------------------------+
+| 8     | VariableMeasured           | R          | 0-n | The variable(s) that     | Free text              |
+|       |                            |            |     | this instrument          |                        |
+|       |                            |            |     | measures or observes     |                        |
++-------+----------------------------+------------+-----+--------------------------+------------------------+
+| 9     | Date                       | R          | 0-n | Dates relevant to the    | ISO 8601               |
+|       |                            |            |     | instrument               |                        |
++-------+----------------------------+------------+-----+--------------------------+------------------------+
+| 9.1   | dateType                   | R          | 1   | The type of the date     | Controlled list        |
+|       |                            |            |     |                          | of values:             |
+|       |                            |            |     |                          |   Commissioned,        |
+|       |                            |            |     |                          |   DeCommissioned,      |
+|       |                            |            |     |                          |   ...                  |
++-------+----------------------------+------------+-----+--------------------------+------------------------+
+| 10    | RelatedIdentifier          | R          | 0-n | Identifiers of related   | Free text, must be     |
+|       |                            |            |     | resources                | globally unique        |
+|       |                            |            |     |                          | identifiers.           |
++-------+----------------------------+------------+-----+--------------------------+------------------------+
+| 10.1  | relatedIdentifierType      | R          | 1   | Type of the identifier   | Controlled list        |
+|       |                            |            |     |                          | of values:             |
+|       |                            |            |     |                          |   PIDINST, DOI,        |
+|       |                            |            |     |                          |   Handle, URL,         |
+|       |                            |            |     |                          |   URN, ...             |
++-------+----------------------------+------------+-----+--------------------------+------------------------+
+| 10.2  | relationType               | R          | 1   | Description of the       | Controlled list        |
+|       |                            |            |     | relationship             | of values:             |
+|       |                            |            |     |                          |   IsDescribedBy,       |
+|       |                            |            |     |                          |   IsNewVersionOf,      |
+|       |                            |            |     |                          |   IsPreviousVersionOf, |
+|       |                            |            |     |                          |   HasComponent,        |
+|       |                            |            |     |                          |   IsComponentOf,       |
+|       |                            |            |     |                          |   References,          |
+|       |                            |            |     |                          |   HasMetadata, ...     |
++-------+----------------------------+------------+-----+--------------------------+------------------------+
+| 11    | AlternateIdentifier        | R          | 0-n | Identifiers other than   | Free text, should be   |
+|       |                            |            |     | the PIDINST pertaining   | unique identifiers     |
+|       |                            |            |     | to the same instrument   |                        |
+|       |                            |            |     | instance.  This should   |                        |
+|       |                            |            |     | be used if the           |                        |
+|       |                            |            |     | instrument has a serial  |                        |
+|       |                            |            |     | number.  Other possible  |                        |
+|       |                            |            |     | uses include an owner's  |                        |
+|       |                            |            |     | inventory number or an   |                        |
+|       |                            |            |     | entry in some instrument |                        |
+|       |                            |            |     | data base.               |                        |
++-------+----------------------------+------------+-----+--------------------------+------------------------+
+| 11.1  | alternateIdentifierType    | R          | 1   | Type of the identifier   | Free text.  Mandatory  |
+|       |                            |            |     |                          | if AlternateIdentifier |
+|       |                            |            |     |                          | is used.  Suggested    |
+|       |                            |            |     |                          | values include:        |
+|       |                            |            |     |                          |   serialNumber,        |
+|       |                            |            |     |                          |   inventoryNumber, ... |
++-------+----------------------------+------------+-----+--------------------------+------------------------+
 
 
 Notes


### PR DESCRIPTION
Amend AlternateIdentifier:
- change obligation to recommended.
- point out that AlternateIdentifier should be used for serial number.  This addresses #5.
- point out that alternateIdentifierType is mandatory if AlternateIdentifier is used.
- add suggested values for alternateIdentifierType.