### PR TITLE
Amend definition of ResourceType in the DataCite schema

### DIFF
--- a/schema-datacite.rst
+++ b/schema-datacite.rst
@@ -166,8 +166,8 @@ should be negotiated with DataCite.
 |       |                            |            |     | about the date, if       |                          |                           |
 |       |                            |            |     | appropriate              |                          |                           |
 +-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 10    | ResourceType               | M          | 1   | A description of the     | Free text.  Suggested    | None                      |
-|       |                            |            |     | resource                 | values:                  |                           |
+| 10    | ResourceType               | M          | 1   | The type of the resource | Free text.  Suggested    | None                      |
+|       |                            |            |     |                          | values:                  |                           |
 |       |                            |            |     |                          |   Platform               |                           |
 |       |                            |            |     |                          |   Instrument             |                           |
 |       |                            |            |     |                          |   Sensor                 |                           |


### PR DESCRIPTION
Resolve #27 changing the definition of `ResourceType` in the DataCite mapping as suggested.

Note that this DataCite mapping is only an instruction on how to map our metadata schema onto the DataCite schema. So this of course won't affect the DataCite schema or the definitions therein.