### PR TITLE
Remove PIDINST as the place holder for the identifier type

### DIFF
--- a/schema.rst
+++ b/schema.rst
@@ -6,13 +6,11 @@ Metadata Schema for the Persistent Identification of Scientific Measuring Instru
 |       |                            |            |     |                          | constraints,           |
 |       |                            |            |     |                          | remarks                |
 +-------+----------------------------+------------+-----+--------------------------+------------------------+
-| 1     | Identifier                 | M          | 1   | Unique string that       | PIDINST                |
+| 1     | Identifier                 | M          | 1   | Unique string that       |                        |
 |       |                            |            |     | identifies the           |                        |
 |       |                            |            |     | instrument instance      |                        |
 +-------+----------------------------+------------+-----+--------------------------+------------------------+
-| 1.1   | identifierType             | M          | 1   | Type of the identifier   | Controlled list        |
-|       |                            |            |     |                          | of values:             |
-|       |                            |            |     |                          |   PIDINST              |
+| 1.1   | identifierType             | M          | 1   | Type of the identifier   | [#identtype]_          |
 +-------+----------------------------+------------+-----+--------------------------+------------------------+
 | 2     | LandingPage                | M          | 1   | A landing page that      | URL                    |
 |       |                            |            |     | the identifier           |                        |
@@ -101,8 +99,7 @@ Metadata Schema for the Persistent Identification of Scientific Measuring Instru
 +-------+----------------------------+------------+-----+--------------------------+------------------------+
 | 11.1  | relatedIdentifierType      | R          | 1   | Type of the identifier   | Controlled list        |
 |       |                            |            |     |                          | of values:             |
-|       |                            |            |     |                          |   PIDINST, DOI,        |
-|       |                            |            |     |                          |   Handle, URL,         |
+|       |                            |            |     |                          |   DOI, Handle, URL,    |
 |       |                            |            |     |                          |   URN, ...             |
 +-------+----------------------------+------------+-----+--------------------------+------------------------+
 | 11.2  | relationType               | R          | 1   | Description of the       | Controlled list        |
@@ -139,8 +136,9 @@ Metadata Schema for the Persistent Identification of Scientific Measuring Instru
 Notes
 -----
 
-- A suitable name for the instrument PID system still needs to be
-  found.  As a place holder, we use PIDINST here.
+.. [#identtype] The type of the identifier depends on the provider
+   being used to register the instrument PID.  In the case of ePIC,
+   the value of `identifierType` would be "Handle".
 
 
 Criteria for adding and classifying properties


### PR DESCRIPTION
We created the schema before we discussed options for the actual implementation and thus, back then, it was not yet known what would be the PID provider to use and the identifier type the PID would end up to be. We used `PIDINST` as a place holder for the identifier type in the schema. Meanwhile, we explored ePIC Handles and DataCite DOIs as implementation options, the latter one using its own variant of the schema.

This PR now drops the `PIDINST` place holder as it already caused confusion, see #32. It adds a remark that the actual type depends on the PID provider being used and that it would be `Handle` in the case of ePIC.