### PR TITLE
Add relatedIdentifierName subproperty

### DIFF
--- a/schema.rst
+++ b/schema.rst
@@ -132,6 +132,11 @@ Metadata Schema for the Persistent Identification of Scientific Measuring Instru
 |       |                              |            |     |                          |   IsIdenticalTo,       |
 |       |                              |            |     |                          |   IsAttachedTo         |
 +-------+------------------------------+------------+-----+--------------------------+------------------------+
+| 12.3  | relatedIdentifierName        | O          | 0-1 | A name for the related   | Free text              |
+|       |                              |            |     | resource, may be used to |                        |
+|       |                              |            |     | give a hint on the       |                        |
+|       |                              |            |     | content of the resource  |                        |
++-------+------------------------------+------------+-----+--------------------------+------------------------+
 | 13    | AlternateIdentifier          | R          | 0-n | Identifiers other than   | Free text, should be   |
 |       |                              |            |     | the PIDINST pertaining   | unique identifiers     |
 |       |                              |            |     | to the same instrument   |                        |

--- a/schema.rst
+++ b/schema.rst
@@ -135,7 +135,7 @@ Metadata Schema for the Persistent Identification of Scientific Measuring Instru
 | 12.3  | relatedIdentifierName        | O          | 0-1 | A name for the related   | Free text              |
 |       |                              |            |     | resource, may be used to |                        |
 |       |                              |            |     | give a hint on the       |                        |
-|       |                              |            |     | content of the resource  |                        |
+|       |                              |            |     | content of that resource |                        |
 +-------+------------------------------+------------+-----+--------------------------+------------------------+
 | 13    | AlternateIdentifier          | R          | 0-n | Identifiers other than   | Free text, should be   |
 |       |                              |            |     | the PIDINST pertaining   | unique identifiers     |


### PR DESCRIPTION
Add the `relatedIdentifierName` subproperty as suggested by @ErinKenna in #54.  Closes #54.

I support the [suggestion](https://github.com/rdawg-pidinst/schema/issues/23#issuecomment-894159199) of @markusstocker that this is a minor change and we still may add it to version 1.0 even though we already had a final decision on this version in the last meeting.