### PR TITLE
Fix typo: one or more Manufacturer is of course occ. 1-n

### DIFF
--- a/doc/schema.tex
+++ b/doc/schema.tex
@@ -214,7 +214,7 @@ have zero or more RelatedIdentifier (occ.\ 0--n).  Each of them must
 have one relatedIdentifierType (occ.\ 1) and one relationType
 (occ.\ 1) and may optionally have one relatedIdentifierName
 (occ.\ 0--1).  Another example: a PIDINST record must have one or more
-Manufacturer (occ.\ 0--n).  Each of them must have a manufacturerName
+Manufacturer (occ.\ 1--n).  Each of them must have a manufacturerName
 (occ.\ 1) and may have a manufacturerIdentifier (occ.\ 0--1).  If a
 manufacturerIdentifier is included for a Manufacturer, it must also
 have a manufacturerIdentifierType (occ.\ 1).


### PR DESCRIPTION
The text in Section 2.2 explaining the meaning of the Occ. column in Table 2 currently reads:

> Another example: a PIDINST record must have one or more Manufacturer (occ. 0-n).

This is obviously wrong. One or more is of course occ. "1-n" and Manufacturer also has that value in the Occ. column.