### PR TITLE
Update Datacite mapping

### DIFF
--- a/schema-datacite.rst
+++ b/schema-datacite.rst
@@ -3,17 +3,11 @@ Metadata Schema for the Persistent Identification of Scientific Measuring Instru
 
 The following table presents the metadata schema for the persistent
 identification of instruments mapped onto the `DataCite Metadata
-Schema 4.6`_.  Note that the current version of the DataCite schema
-has not been designed to describe instruments.  As a consequence, some
+Schema 4.6`_.  Note that the the DataCite schema has not specifically
+been designed to describe instruments.  As a consequence, some
 definitions in the DataCite schema need to be stretched.  For a few
 relevant instrument properties there is even no suitable place in the
 DataCite schema at all.
-
-In this presentation, the DataCite schema is mostly taken as is,
-assuming that no adaptations are made to accommodate instruments.
-Nevertheless, there are some shortcomings of this approach, so some
-amendments of the schema would facilitate its use for instruments and
-should be negotiated with DataCite.
 
 
 +-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+

--- a/schema-datacite.rst
+++ b/schema-datacite.rst
@@ -3,7 +3,7 @@ Metadata Schema for the Persistent Identification of Scientific Measuring Instru
 
 The following table presents the metadata schema for the persistent
 identification of instruments mapped onto the `DataCite Metadata
-Schema 4.4`_.  Note that the current version of the DataCite schema
+Schema 4.6`_.  Note that the current version of the DataCite schema
 has not been designed to describe instruments.  As a consequence, some
 definitions in the DataCite schema need to be stretched.  For a few
 relevant instrument properties there is even no suitable place in the
@@ -359,4 +359,4 @@ ordered by increasing importance, from least concern to critical:
   specifications, but not an individual instrument.
 
 
-.. _DataCite Metadata Schema 4.4: https://schema.datacite.org/meta/kernel-4.4/
+.. _DataCite Metadata Schema 4.6: https://schema.datacite.org/meta/kernel-4.6/

--- a/schema-datacite.rst
+++ b/schema-datacite.rst
@@ -9,6 +9,11 @@ definitions in the DataCite schema need to be stretched.  For a few
 relevant instrument properties there is even no suitable place in the
 DataCite schema at all.
 
+Since version 4.5, the DataCite schema also includes a `mapping from
+the PIDINST Schema onto DataCite <DataCite PIDINST Mapping_>`_.
+Some more discussion on the representation of PIDINST in the DataCite
+Schema is also provided in the `Section on metadata in the DataCite
+Cookbook <DataCite Cookbook metadata_>`_.
 
 +-------+----------------------------+------------+-----+--------------------------+--------------------------+
 | ID    | Property                   | Obligation | Occ | Definition               | Allowed values,          |
@@ -343,3 +348,5 @@ ordered by increasing importance, from least concern to critical:
 
 
 .. _DataCite Metadata Schema 4.6: https://schema.datacite.org/meta/kernel-4.6/
+.. _DataCite PIDINST Mapping: https://datacite-metadata-schema.readthedocs.io/en/latest/mappings/pidinst/
+.. _DataCite Cookbook metadata: https://docs.pidinst.org/en/latest/datacite-cookbook/metadata.html

--- a/schema-datacite.rst
+++ b/schema-datacite.rst
@@ -10,223 +10,223 @@ relevant instrument properties there is even no suitable place in the
 DataCite schema at all.
 
 
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| ID    | Property                   | Obligation | Occ | Definition               | Allowed values,          | Suggested Changes         |
-|       |                            |            |     |                          | constraints,             | to DataCite               |
-|       |                            |            |     |                          | remarks                  | schema                    |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 1     | Identifier                 | M          | 1   | Unique string that       | DOI                      | None                      |
-|       |                            |            |     | identifies the           |                          |                           |
-|       |                            |            |     | instrument instance      |                          |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 1.a   | identifierType             | M          | 1   | Type of the identifier   | Controlled list of       | None                      |
-|       |                            |            |     |                          | values:[#identtype]_     |                           |
-|       |                            |            |     |                          |   DOI                    |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 2     | Creator                    | M          | 1-n | The instrument's         |                          | None                      |
-|       |                            |            |     | manufacturer(s) or       |                          |                           |
-|       |                            |            |     | developer. This may      |                          |                           |
-|       |                            |            |     | also be the owner for    |                          |                           |
-|       |                            |            |     | custom build             |                          |                           |
-|       |                            |            |     | instruments              |                          |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 2.1   | creatorName                | M          | 1   | Full name of the         | Free text                | None                      |
-|       |                            |            |     | manufacturer             |                          |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 2.1.a | nameType                   | R          | 0-1 | The type of name         | Controlled list of       | None                      |
-|       |                            |            |     |                          | values:[#cr_nametype]_   |                           |
-|       |                            |            |     |                          | **Organizational**       |                           |
-|       |                            |            |     |                          |   Personal               |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 2.2   | givenName                  | R          | 0-1 | First name of the        | Free text                | None                      |
-|       |                            |            |     | manufacturer, if         |                          |                           |
-|       |                            |            |     | applicable               |                          |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 2.3   | familyName                 | R          | 0-1 | Last name of the         | Free text                | None                      |
-|       |                            |            |     | manufacturer, if         |                          |                           |
-|       |                            |            |     | applicable               |                          |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 2.4   | nameIdentifier             | R          | 0-n | Unique identifier of the | Free text, format is     | None                      |
-|       |                            |            |     | manufacturer             | dependent upon schema    |                           |
-|       |                            |            |     |                          |                          |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 2.4.a | nameIdentifierScheme       | R          | 1   | The name of the name     | Free text, mandatory     | None                      |
-|       |                            |            |     | identifier schema        | if nameIdentifier is     |                           |
-|       |                            |            |     |                          | used. Examples: ROR,     |                           |
-|       |                            |            |     |                          | ISNI, ORCID              |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 2.4.b | schemeURI                  | O          | 0-1 | The URI of the name      | Examples:                | None                      |
-|       |                            |            |     | identifier schema        | **http://www.isni.org**, |                           |
-|       |                            |            |     |                          | https://orcid.org        |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 2.5   | affiliation                | O          | 0-n | Organizational or        | Free text                | None                      |
-|       |                            |            |     | institutional            | [#cr_affiliation]_       |                           |
-|       |                            |            |     | affiliation of the       |                          |                           |
-|       |                            |            |     | manufacturer             |                          |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 3     | Title                      | M          | 1   | Name by which the        | Free text                | None                      |
-|       |                            |            |     | instrument instance is   |                          |                           |
-|       |                            |            |     | known                    |                          |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 3.a   | titleType                  | O          | 0-1 | The type of Title        | Controlled list of       | Add *Name* to controlled  |
-|       |                            |            |     |                          | values:[#titletype]_     | list of values            |
-|       |                            |            |     |                          |   AlternativeTitle       |                           |
-|       |                            |            |     |                          |   Subtitle               |                           |
-|       |                            |            |     |                          |   TranslatedTitle        |                           |
-|       |                            |            |     |                          |   **Other**              |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 4     | Publisher                  | M          | 1   | The name of the entity   | Free text                | None                      |
-|       |                            |            |     | that holds, archives,    | [#publisher]_            |                           |
-|       |                            |            |     | publishes, prints,       |                          |                           |
-|       |                            |            |     | distributes, releases,   |                          |                           |
-|       |                            |            |     | issues, or produces the  |                          |                           |
-|       |                            |            |     | resource                 |                          |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 5     | PublicationYear            | M          | 1   | The year when the data   | YYYY [#pubyear]_         | None                      |
-|       |                            |            |     | was made publicly        |                          |                           |
-|       |                            |            |     | available                |                          |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 6     | Subject                    | R          | 0-n | Subject, keyword,        |  Free text [#subject]_   | None                      |
-|       |                            |            |     | classification code, or  |                          |                           |
-|       |                            |            |     | key phrase describing    |                          |                           |
-|       |                            |            |     | the instrument           |                          |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 6.a   | subjectScheme              | O          | 0-1 | The name of the subject  | Free text                | None                      |
-|       |                            |            |     | scheme or classification |                          |                           |
-|       |                            |            |     | code or authority if one |                          |                           |
-|       |                            |            |     | is used                  |                          |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 6.b   | schemeURI                  | O          | 0-1 | The URI of the subject   |                          | None                      |
-|       |                            |            |     | identifier scheme        |                          |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 6.c   | valueURI                   | O          | 0-1 | The URI of the subject   |                          | None                      |
-|       |                            |            |     | term                     |                          |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 7     | Contributor                | M          | 1-n | Institution(s)           | [#contributor]_          | None                      |
-|       |                            |            |     | responsible for the      |                          |                           |
-|       |                            |            |     | management of the        |                          |                           |
-|       |                            |            |     | instrument. This may     |                          |                           |
-|       |                            |            |     | include the legal        |                          |                           |
-|       |                            |            |     | owner, the operator,     |                          |                           |
-|       |                            |            |     | or an institute          |                          |                           |
-|       |                            |            |     | providing access to      |                          |                           |
-|       |                            |            |     | the instrument.          |                          |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 7.a   | contributorType            | M          | 1   | The type of contributor  | Controlled list of       | None                      |
-|       |                            |            |     |                          | values:                  |                           |
-|       |                            |            |     |                          | **hostingInstitution**   |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 7.1   | contributorName            | M          | 1   | Full name of the owner   | Free text                | None                      |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 7.1.a | nameType                   | R          | 0-1 | The type of name         | Controlled list of       | None                      |
-|       |                            |            |     |                          | values:[#cntrb_sub]_     |                           |
-|       |                            |            |     |                          |   Organizational         |                           |
-|       |                            |            |     |                          |   Personal               |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 7.2   | givenName                  | R          | 0-1 | First name of the        | Free text                | None                      |
-|       |                            |            |     | owner, if                |                          |                           |
-|       |                            |            |     | applicable               |                          |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 7.3   | familyName                 | R          | 0-1 | Last name of the         | Free text                | None                      |
-|       |                            |            |     | owner, if                |                          |                           |
-|       |                            |            |     | applicable               |                          |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 7.4   | nameIdentifier             | R          | 0-n | Unique identifier of the | Free text, format is     | None                      |
-|       |                            |            |     | owner                    | dependent upon schema    |                           |
-|       |                            |            |     |                          |                          |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 7.4.a | nameIdentifierScheme       | R          | 1   | The name of the name     | Free text, mandatory     | None                      |
-|       |                            |            |     | identifier schema        | if nameIdentifier is     |                           |
-|       |                            |            |     |                          | used. Examples: ROR,     |                           |
-|       |                            |            |     |                          | ISNI, ORCID              |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 7.4.b | schemeURI                  | O          | 0-1 | The URI of the name      | Examples:                | None                      |
-|       |                            |            |     | identifier schema        | http://www.isni.org,     |                           |
-|       |                            |            |     |                          | https://orcid.org        |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 7.5   | affiliation                | O          | 0-n | Organizational or        | Free text                | None                      |
-|       |                            |            |     | institutional            | [#cntrb_sub]_            |                           |
-|       |                            |            |     | affiliation of the       |                          |                           |
-|       |                            |            |     | contributor              |                          |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 8     | Date                       | R          | 0-n | Dates relevant to the    | ISO 8601 [#date]_        | None                      |
-|       |                            |            |     | instrument               |                          |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 8.a   | dateType                   | R          | 1   | The type of the date     | Controlled list of       | None                      |
-|       |                            |            |     |                          | values, see DataCite     |                           |
-|       |                            |            |     |                          | schema                   |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 8.b   | dateInformation            | O          | 0-1 | Specific information     | Free text                | None                      |
-|       |                            |            |     | about the date, if       |                          |                           |
-|       |                            |            |     | appropriate              |                          |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 10    | ResourceType               | M          | 1   | The type of the resource | Free text.  Suggested    | None                      |
-|       |                            |            |     |                          | values:                  |                           |
-|       |                            |            |     |                          |   Platform               |                           |
-|       |                            |            |     |                          |   Instrument             |                           |
-|       |                            |            |     |                          |   Sensor                 |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 10.a  | resourceTypeGeneral        | M          | 1   | The general type of the  | Controlled list of       | None                      |
-|       |                            |            |     | resource                 | values:[#restypegen]_    |                           |
-|       |                            |            |     |                          |   **Instrument**         |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 11    | AlternateIdentifier        | R          | 0-n | Identifiers other than   | Free text, should be     | None                      |
-|       |                            |            |     | the DOI pertaining to    | unique identifiers       |                           |
-|       |                            |            |     | the same instrument      |                          |                           |
-|       |                            |            |     | instance.  This should   |                          |                           |
-|       |                            |            |     | be used if the           |                          |                           |
-|       |                            |            |     | instrument has a serial  |                          |                           |
-|       |                            |            |     | number.  Other possible  |                          |                           |
-|       |                            |            |     | uses include an owner's  |                          |                           |
-|       |                            |            |     | inventory number or an   |                          |                           |
-|       |                            |            |     | entry in some instrument |                          |                           |
-|       |                            |            |     | data base.               |                          |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 11.a  | alternateIdentifierType    | R          | 1   | Type of the identifier   | Free text.  Mandatory    | None                      |
-|       |                            |            |     |                          | if AlternateIdentifier   |                           |
-|       |                            |            |     |                          | is used.  Suggested      |                           |
-|       |                            |            |     |                          | values include:          |                           |
-|       |                            |            |     |                          |   serialNumber           |                           |
-|       |                            |            |     |                          |   inventoryNumber        |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 12    | RelatedIdentifier          | R          | 0-n | Identifiers of related   | Free text, must be       | None                      |
-|       |                            |            |     | resources                | globally unique          |                           |
-|       |                            |            |     |                          | identifiers.             |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 12.a  | relatedIdentifierType      | R          | 1   | Type of the identifier   | Controlled list of       | None                      |
-|       |                            |            |     |                          | values, see DataCite     |                           |
-|       |                            |            |     |                          | schema                   |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 12.b  | relationType               | R          | 1   | Description of the       | Controlled list of       | Add a relationType for    |
-|       |                            |            |     | relationship             | values, see DataCite     | deployments, indicating   |
-|       |                            |            |     |                          | schema [#reltype]_       | *was used in*             |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 12.c  | relatedMetaDataScheme      | O          | 0-1 | The name of the related  | Use only for             | None                      |
-|       |                            |            |     | metadata scheme          | HasMetadata              |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 12.d  | schemeURI                  | O          | 0-1 | The URI of the related   | Use only for             | None                      |
-|       |                            |            |     | metadata scheme          | HasMetadata              |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 12.e  | schemeType                 | O          | 0-1 | The type of the related  | Use only for             | None                      |
-|       |                            |            |     | metadata scheme          | HasMetadata              |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 12.f  | resourceTypeGeneral        | O          | 0-1 | The general type of the  | Controlled list of       | Add *Instrument* to       |
-|       |                            |            |     | related resource         | values, see DataCite     | controlled list of values |
-|       |                            |            |     |                          | schema **Other**         |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 17    | Description                | R          | 0-n | Technical description    | Free text                | None                      |
-|       |                            |            |     | of the device and its    |                          |                           |
-|       |                            |            |     | capabilities             |                          |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
-| 17.a  | descriptionType            | R          | 1   | The type of the          | Controlled list of       | None                      |
-|       |                            |            |     | description              | values:[#desctype]_      |                           |
-|       |                            |            |     |                          |   Abstract               |                           |
-|       |                            |            |     |                          |   Methods                |                           |
-|       |                            |            |     |                          |   SeriesInformation      |                           |
-|       |                            |            |     |                          |   TableOfContents        |                           |
-|       |                            |            |     |                          |   TechnicalInfo          |                           |
-|       |                            |            |     |                          |   Other                  |                           |
-+-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| ID    | Property                   | Obligation | Occ | Definition               | Allowed values,          |
+|       |                            |            |     |                          | constraints,             |
+|       |                            |            |     |                          | remarks                  |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 1     | Identifier                 | M          | 1   | Unique string that       | DOI                      |
+|       |                            |            |     | identifies the           |                          |
+|       |                            |            |     | instrument instance      |                          |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 1.a   | identifierType             | M          | 1   | Type of the identifier   | Controlled list of       |
+|       |                            |            |     |                          | values:[#identtype]_     |
+|       |                            |            |     |                          |   DOI                    |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 2     | Creator                    | M          | 1-n | The instrument's         |                          |
+|       |                            |            |     | manufacturer(s) or       |                          |
+|       |                            |            |     | developer. This may      |                          |
+|       |                            |            |     | also be the owner for    |                          |
+|       |                            |            |     | custom build             |                          |
+|       |                            |            |     | instruments              |                          |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 2.1   | creatorName                | M          | 1   | Full name of the         | Free text                |
+|       |                            |            |     | manufacturer             |                          |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 2.1.a | nameType                   | R          | 0-1 | The type of name         | Controlled list of       |
+|       |                            |            |     |                          | values:[#cr_nametype]_   |
+|       |                            |            |     |                          | **Organizational**       |
+|       |                            |            |     |                          |   Personal               |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 2.2   | givenName                  | R          | 0-1 | First name of the        | Free text                |
+|       |                            |            |     | manufacturer, if         |                          |
+|       |                            |            |     | applicable               |                          |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 2.3   | familyName                 | R          | 0-1 | Last name of the         | Free text                |
+|       |                            |            |     | manufacturer, if         |                          |
+|       |                            |            |     | applicable               |                          |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 2.4   | nameIdentifier             | R          | 0-n | Unique identifier of the | Free text, format is     |
+|       |                            |            |     | manufacturer             | dependent upon schema    |
+|       |                            |            |     |                          |                          |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 2.4.a | nameIdentifierScheme       | R          | 1   | The name of the name     | Free text, mandatory     |
+|       |                            |            |     | identifier schema        | if nameIdentifier is     |
+|       |                            |            |     |                          | used. Examples: ROR,     |
+|       |                            |            |     |                          | ISNI, ORCID              |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 2.4.b | schemeURI                  | O          | 0-1 | The URI of the name      | Examples:                |
+|       |                            |            |     | identifier schema        | **http://www.isni.org**, |
+|       |                            |            |     |                          | https://orcid.org        |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 2.5   | affiliation                | O          | 0-n | Organizational or        | Free text                |
+|       |                            |            |     | institutional            | [#cr_affiliation]_       |
+|       |                            |            |     | affiliation of the       |                          |
+|       |                            |            |     | manufacturer             |                          |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 3     | Title                      | M          | 1   | Name by which the        | Free text                |
+|       |                            |            |     | instrument instance is   |                          |
+|       |                            |            |     | known                    |                          |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 3.a   | titleType                  | O          | 0-1 | The type of Title        | Controlled list of       |
+|       |                            |            |     |                          | values:[#titletype]_     |
+|       |                            |            |     |                          |   AlternativeTitle       |
+|       |                            |            |     |                          |   Subtitle               |
+|       |                            |            |     |                          |   TranslatedTitle        |
+|       |                            |            |     |                          |   **Other**              |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 4     | Publisher                  | M          | 1   | The name of the entity   | Free text                |
+|       |                            |            |     | that holds, archives,    | [#publisher]_            |
+|       |                            |            |     | publishes, prints,       |                          |
+|       |                            |            |     | distributes, releases,   |                          |
+|       |                            |            |     | issues, or produces the  |                          |
+|       |                            |            |     | resource                 |                          |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 5     | PublicationYear            | M          | 1   | The year when the data   | YYYY [#pubyear]_         |
+|       |                            |            |     | was made publicly        |                          |
+|       |                            |            |     | available                |                          |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 6     | Subject                    | R          | 0-n | Subject, keyword,        |  Free text [#subject]_   |
+|       |                            |            |     | classification code, or  |                          |
+|       |                            |            |     | key phrase describing    |                          |
+|       |                            |            |     | the instrument           |                          |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 6.a   | subjectScheme              | O          | 0-1 | The name of the subject  | Free text                |
+|       |                            |            |     | scheme or classification |                          |
+|       |                            |            |     | code or authority if one |                          |
+|       |                            |            |     | is used                  |                          |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 6.b   | schemeURI                  | O          | 0-1 | The URI of the subject   |                          |
+|       |                            |            |     | identifier scheme        |                          |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 6.c   | valueURI                   | O          | 0-1 | The URI of the subject   |                          |
+|       |                            |            |     | term                     |                          |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 7     | Contributor                | M          | 1-n | Institution(s)           | [#contributor]_          |
+|       |                            |            |     | responsible for the      |                          |
+|       |                            |            |     | management of the        |                          |
+|       |                            |            |     | instrument. This may     |                          |
+|       |                            |            |     | include the legal        |                          |
+|       |                            |            |     | owner, the operator,     |                          |
+|       |                            |            |     | or an institute          |                          |
+|       |                            |            |     | providing access to      |                          |
+|       |                            |            |     | the instrument.          |                          |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 7.a   | contributorType            | M          | 1   | The type of contributor  | Controlled list of       |
+|       |                            |            |     |                          | values:                  |
+|       |                            |            |     |                          | **hostingInstitution**   |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 7.1   | contributorName            | M          | 1   | Full name of the owner   | Free text                |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 7.1.a | nameType                   | R          | 0-1 | The type of name         | Controlled list of       |
+|       |                            |            |     |                          | values:[#cntrb_sub]_     |
+|       |                            |            |     |                          |   Organizational         |
+|       |                            |            |     |                          |   Personal               |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 7.2   | givenName                  | R          | 0-1 | First name of the        | Free text                |
+|       |                            |            |     | owner, if                |                          |
+|       |                            |            |     | applicable               |                          |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 7.3   | familyName                 | R          | 0-1 | Last name of the         | Free text                |
+|       |                            |            |     | owner, if                |                          |
+|       |                            |            |     | applicable               |                          |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 7.4   | nameIdentifier             | R          | 0-n | Unique identifier of the | Free text, format is     |
+|       |                            |            |     | owner                    | dependent upon schema    |
+|       |                            |            |     |                          |                          |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 7.4.a | nameIdentifierScheme       | R          | 1   | The name of the name     | Free text, mandatory     |
+|       |                            |            |     | identifier schema        | if nameIdentifier is     |
+|       |                            |            |     |                          | used. Examples: ROR,     |
+|       |                            |            |     |                          | ISNI, ORCID              |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 7.4.b | schemeURI                  | O          | 0-1 | The URI of the name      | Examples:                |
+|       |                            |            |     | identifier schema        | http://www.isni.org,     |
+|       |                            |            |     |                          | https://orcid.org        |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 7.5   | affiliation                | O          | 0-n | Organizational or        | Free text                |
+|       |                            |            |     | institutional            | [#cntrb_sub]_            |
+|       |                            |            |     | affiliation of the       |                          |
+|       |                            |            |     | contributor              |                          |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 8     | Date                       | R          | 0-n | Dates relevant to the    | ISO 8601 [#date]_        |
+|       |                            |            |     | instrument               |                          |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 8.a   | dateType                   | R          | 1   | The type of the date     | Controlled list of       |
+|       |                            |            |     |                          | values, see DataCite     |
+|       |                            |            |     |                          | schema                   |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 8.b   | dateInformation            | O          | 0-1 | Specific information     | Free text                |
+|       |                            |            |     | about the date, if       |                          |
+|       |                            |            |     | appropriate              |                          |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 10    | ResourceType               | M          | 1   | The type of the resource | Free text.  Suggested    |
+|       |                            |            |     |                          | values:                  |
+|       |                            |            |     |                          |   Platform               |
+|       |                            |            |     |                          |   Instrument             |
+|       |                            |            |     |                          |   Sensor                 |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 10.a  | resourceTypeGeneral        | M          | 1   | The general type of the  | Controlled list of       |
+|       |                            |            |     | resource                 | values:[#restypegen]_    |
+|       |                            |            |     |                          |   **Instrument**         |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 11    | AlternateIdentifier        | R          | 0-n | Identifiers other than   | Free text, should be     |
+|       |                            |            |     | the DOI pertaining to    | unique identifiers       |
+|       |                            |            |     | the same instrument      |                          |
+|       |                            |            |     | instance.  This should   |                          |
+|       |                            |            |     | be used if the           |                          |
+|       |                            |            |     | instrument has a serial  |                          |
+|       |                            |            |     | number.  Other possible  |                          |
+|       |                            |            |     | uses include an owner's  |                          |
+|       |                            |            |     | inventory number or an   |                          |
+|       |                            |            |     | entry in some instrument |                          |
+|       |                            |            |     | data base.               |                          |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 11.a  | alternateIdentifierType    | R          | 1   | Type of the identifier   | Free text.  Mandatory    |
+|       |                            |            |     |                          | if AlternateIdentifier   |
+|       |                            |            |     |                          | is used.  Suggested      |
+|       |                            |            |     |                          | values include:          |
+|       |                            |            |     |                          |   serialNumber           |
+|       |                            |            |     |                          |   inventoryNumber        |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 12    | RelatedIdentifier          | R          | 0-n | Identifiers of related   | Free text, must be       |
+|       |                            |            |     | resources                | globally unique          |
+|       |                            |            |     |                          | identifiers.             |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 12.a  | relatedIdentifierType      | R          | 1   | Type of the identifier   | Controlled list of       |
+|       |                            |            |     |                          | values, see DataCite     |
+|       |                            |            |     |                          | schema                   |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 12.b  | relationType               | R          | 1   | Description of the       | Controlled list of       |
+|       |                            |            |     | relationship             | values, see DataCite     |
+|       |                            |            |     |                          | schema [#reltype]_       |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 12.c  | relatedMetaDataScheme      | O          | 0-1 | The name of the related  | Use only for             |
+|       |                            |            |     | metadata scheme          | HasMetadata              |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 12.d  | schemeURI                  | O          | 0-1 | The URI of the related   | Use only for             |
+|       |                            |            |     | metadata scheme          | HasMetadata              |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 12.e  | schemeType                 | O          | 0-1 | The type of the related  | Use only for             |
+|       |                            |            |     | metadata scheme          | HasMetadata              |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 12.f  | resourceTypeGeneral        | O          | 0-1 | The general type of the  | Controlled list of       |
+|       |                            |            |     | related resource         | values, see DataCite     |
+|       |                            |            |     |                          | schema **Other**         |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 17    | Description                | R          | 0-n | Technical description    | Free text                |
+|       |                            |            |     | of the device and its    |                          |
+|       |                            |            |     | capabilities             |                          |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
+| 17.a  | descriptionType            | R          | 1   | The type of the          | Controlled list of       |
+|       |                            |            |     | description              | values:[#desctype]_      |
+|       |                            |            |     |                          |   Abstract               |
+|       |                            |            |     |                          |   Methods                |
+|       |                            |            |     |                          |   SeriesInformation      |
+|       |                            |            |     |                          |   TableOfContents        |
+|       |                            |            |     |                          |   TechnicalInfo          |
+|       |                            |            |     |                          |   Other                  |
++-------+----------------------------+------------+-----+--------------------------+--------------------------+
 
 
 Footnotes

--- a/schema-datacite.rst
+++ b/schema-datacite.rst
@@ -53,10 +53,10 @@ DataCite schema at all.
 | 2.4.a | nameIdentifierScheme       | R          | 1   | The name of the name     | Free text, mandatory     |
 |       |                            |            |     | identifier schema        | if nameIdentifier is     |
 |       |                            |            |     |                          | used. Examples: ROR,     |
-|       |                            |            |     |                          | ISNI, ORCID              |
+|       |                            |            |     |                          | ORCID                    |
 +-------+----------------------------+------------+-----+--------------------------+--------------------------+
 | 2.4.b | schemeURI                  | O          | 0-1 | The URI of the name      | Examples:                |
-|       |                            |            |     | identifier schema        | **http://www.isni.org**, |
+|       |                            |            |     | identifier schema        | **https://ror.org**,     |
 |       |                            |            |     |                          | https://orcid.org        |
 +-------+----------------------------+------------+-----+--------------------------+--------------------------+
 | 2.5   | affiliation                | O          | 0-n | Organizational or        | Free text                |
@@ -138,10 +138,10 @@ DataCite schema at all.
 | 7.4.a | nameIdentifierScheme       | R          | 1   | The name of the name     | Free text, mandatory     |
 |       |                            |            |     | identifier schema        | if nameIdentifier is     |
 |       |                            |            |     |                          | used. Examples: ROR,     |
-|       |                            |            |     |                          | ISNI, ORCID              |
+|       |                            |            |     |                          | ORCID                    |
 +-------+----------------------------+------------+-----+--------------------------+--------------------------+
 | 7.4.b | schemeURI                  | O          | 0-1 | The URI of the name      | Examples:                |
-|       |                            |            |     | identifier schema        | http://www.isni.org,     |
+|       |                            |            |     | identifier schema        | https://ror.org,         |
 |       |                            |            |     |                          | https://orcid.org        |
 +-------+----------------------------+------------+-----+--------------------------+--------------------------+
 | 7.5   | affiliation                | O          | 0-n | Organizational or        | Free text                |

--- a/schema-datacite.rst
+++ b/schema-datacite.rst
@@ -168,7 +168,7 @@ DataCite schema at all.
 +-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
 | 10.a  | resourceTypeGeneral        | M          | 1   | The general type of the  | Controlled list of       | None                      |
 |       |                            |            |     | resource                 | values:[#restypegen]_    |                           |
-|       |                            |            |     |                          |   **Other**              |                           |
+|       |                            |            |     |                          |   **Instrument**         |                           |
 +-------+----------------------------+------------+-----+--------------------------+--------------------------+---------------------------+
 | 11    | AlternateIdentifier        | R          | 0-n | Identifiers other than   | Free text, should be     | None                      |
 |       |                            |            |     | the DOI pertaining to    | unique identifiers       |                           |
@@ -268,9 +268,8 @@ Footnotes
    instrument was in operation, either with a single date to indicate
    when this instrument instance started operation, or a date interval
    if this instrument instance ceased to be in operation.
-.. [#restypegen] None of the specific values for `resourceTypeGeneral`
-   in the DataCite schema fits an instrument. This leaves "Other" as
-   the only option.
+.. [#restypegen] The DataCite schema includes "Instrument" in the
+   controlled list of values for `resourceTypeGeneral`.
 .. [#reltype] Use "HasPart" and "IsPartOf" in lieu of "HasComponent"
    and "IsComponentOf".
 .. [#desctype] Not all of the listed values for `descriptionType`
@@ -299,16 +298,6 @@ ordered by increasing importance, from least concern to critical:
   `RelatedIdentifier` / `relationType=HasMetadata` using some
   externally defined ontology seem to be the most viable approach
   anyway.
-
-+ It should be possible to tell from the PID and its metadata that
-  this one pertains to an instrument and not any other kind of
-  resource.  The only property in the DataCite schema suitable to hold
-  this information is `ResourceType` and its subproperty
-  `resourceTypeGeneral`.  `ResourceType` is free text which does not
-  offer a reliable classification.  The only usuable value for
-  `resourceTypeGeneral` is "Other".  It would be desirable to add
-  "Instrument" to the controlled list of values for
-  `resourceTypeGeneral`.
 
 + It is not obvious that the name of the instrument would be in
   `Title`.  This difficulty is even aggravated by the fact that there


### PR DESCRIPTION
The mapping of the PIDINST schema onto DataCite is outdated.  Updates:
- Link to the current version 4.6 of the DataCite Schema,
- DataCite `resourceTypeGeneral` now has `Instrument`,
- Drop the remark suggesting an update to the DataCite Schema in the introduction and the column "Suggested Changes to DataCite schema" in the table,
- Add references to the mapping provided by DataCite and our own DataCite Cookbook,
- Minor: drop references to ISNI, considered obsolete by now.