### PR TITLE
Make MeasuredVariable a complex property

### DIFF
--- a/schema.rst
+++ b/schema.rst
@@ -93,9 +93,19 @@ Metadata Schema for the Persistent Identification of Scientific Measuring Instru
 +--------+------------------------------------+------------+-----+--------------------------+------------------------+
 | 9.2.1  | instrumentTypeIdentifierType       | O          | 1   | Type of the identifier   | Free text              |
 +--------+------------------------------------+------------+-----+--------------------------+------------------------+
-| 10     | MeasuredVariable                   | R          | 0-n | The variable(s) that     | Free text              |
+| 10     | MeasuredVariable                   | R          | 0-n | The variable(s) that     |                        |
 |        |                                    |            |     | this instrument          |                        |
 |        |                                    |            |     | measures or observes     |                        |
++--------+------------------------------------+------------+-----+--------------------------+------------------------+
+| 10.1   | measuredVariableName               | R          | 1   | Full name of the         | Free text              |
+|        |                                    |            |     | variable                 |                        |
++--------+------------------------------------+------------+-----+--------------------------+------------------------+
+| 10.2   | measuredVariableIdentifier         | O          | 0-1 | Identifier used to       | Free text, should be a |
+|        |                                    |            |     | identify the variable    | globally unique        |
+|        |                                    |            |     |                          | identifier             |
++--------+------------------------------------+------------+-----+--------------------------+------------------------+
+| 10.2.1 | measuredVariableIdentifierType     | O          | 1   | Type of the identifier   | Free text              |
+|        |                                    |            |     |                          |                        |
 +--------+------------------------------------+------------+-----+--------------------------+------------------------+
 | 11     | Date                               | R          | 0-n | Dates relevant to the    | ISO 8601               |
 |        |                                    |            |     | instrument               |                        |


### PR DESCRIPTION
Change property `MeasuredVariable`, which is a simple free text property by now, into a complex property having the subproperties `measuredVariableName`, `measuredVariableIdentifier` and `measuredVariableIdentifierType`. This is done to allow linking with a term from controlled vocabulary. If that (external) controlled vocabulary defines persistent identifiers for its terms, that identifier would be stored in `measuredVariableIdentifier`.

This complex property follows the same structure that we also have for instance in `Model` or `InstrumentType`. Close #68.

The new structure of the property will be:

| ID     | Property                       | Obligation | Occ | Definition                                                | Allowed values, constraints, remarks              |
|--------|--------------------------------|------------|-----|-----------------------------------------------------------|---------------------------------------------------|
| 10     | MeasuredVariable               | R          | 0-n | The variable(s) that this instrument measures or observes |                                                   |
| 10.1   | measuredVariableName           | R          | 1   | Full name of the variable                                 | Free text                                         |
| 10.2   | measuredVariableIdentifier     | O          | 0-1 | Identifier used to identify the variable                  | Free text, should be a globally unique identifier |
| 10.2.1 | measuredVariableIdentifierType | O          | 1   | Type of the identifier                                    | Free text                                         |
