### PR TITLE
Add MeasurementTechnique

### DIFF
--- a/schema.rst
+++ b/schema.rst
@@ -161,23 +161,23 @@ Metadata Schema for the Persistent Identification of Scientific Measuring Instru
 |        |                                    |            |     | alternateIdentifierType  |                        |
 |        |                                    |            |     | is Other.                |                        |
 +--------+------------------------------------+------------+-----+--------------------------+------------------------+
-| XX     | MeasurementTechnique               | R          | 0-n | The protocol that the    |                        |
+| 14     | MeasurementTechnique               | R          | 0-n | The protocol that the    |                        |
 |        |                                    |            |     | instrument follows or    |                        |
 |        |                                    |            |     | the physical phenomenon  |                        |
 |        |                                    |            |     | it makes use of in order |                        |
 |        |                                    |            |     | to make its observation  |                        |
 +--------+------------------------------------+------------+-----+--------------------------+------------------------+
-| XX.1   | measurementTechniqueName           | R          | 1   | Full name of the         | Free text              |
+| 14.1   | measurementTechniqueName           | R          | 1   | Full name of the         | Free text              |
 |        |                                    |            |     | measurement technique    |                        |
 |        |                                    |            |     |                          |                        |
 |        |                                    |            |     |                          |                        |
 |        |                                    |            |     |                          |                        |
 +--------+------------------------------------+------------+-----+--------------------------+------------------------+
-| XX.2   | measurementTechniqueIdentifier     | O          | 0-1 | Identifier used to       | Free text, should be a |
+| 14.2   | measurementTechniqueIdentifier     | O          | 0-1 | Identifier used to       | Free text, should be a |
 |        |                                    |            |     | identify the mesurment   | globally unique        |
 |        |                                    |            |     | technique                | identifier             |
 +--------+------------------------------------+------------+-----+--------------------------+------------------------+
-| XX.2.1 | measurementTechniqueIdentifierType | O          | 1   | Type of the identifier   | Free text              |
+| 14.2.1 | measurementTechniqueIdentifierType | O          | 1   | Type of the identifier   | Free text              |
 +--------+------------------------------------+------------+-----+--------------------------+------------------------+
 
 Definition of terms in controlled lists of values

--- a/schema.rst
+++ b/schema.rst
@@ -165,7 +165,7 @@ Metadata Schema for the Persistent Identification of Scientific Measuring Instru
 |        |                                    |            |     | instrument follows or    |                        |
 |        |                                    |            |     | the physical phenomenon  |                        |
 |        |                                    |            |     | it makes use of in order |                        |
-|        |                                    |            |     | make its observation     |                        |
+|        |                                    |            |     | to make its observation  |                        |
 +--------+------------------------------------+------------+-----+--------------------------+------------------------+
 | XX.1   | measurementTechniqueName           | R          | 1   | Full name of the         | Free text              |
 |        |                                    |            |     | measurement technique    |                        |

--- a/schema.rst
+++ b/schema.rst
@@ -161,6 +161,24 @@ Metadata Schema for the Persistent Identification of Scientific Measuring Instru
 |        |                                    |            |     | alternateIdentifierType  |                        |
 |        |                                    |            |     | is Other.                |                        |
 +--------+------------------------------------+------------+-----+--------------------------+------------------------+
+| XX     | MeasurementTechnique               | R          | 0-n | The protocol that the    |                        |
+|        |                                    |            |     | instrument follows or    |                        |
+|        |                                    |            |     | the physical phenomenon  |                        |
+|        |                                    |            |     | it makes use of in order |                        |
+|        |                                    |            |     | make its observation     |                        |
++--------+------------------------------------+------------+-----+--------------------------+------------------------+
+| XX.1   | measurementTechniqueName           | R          | 1   | Full name of the         | Free text              |
+|        |                                    |            |     | measurement technique    |                        |
+|        |                                    |            |     |                          |                        |
+|        |                                    |            |     |                          |                        |
+|        |                                    |            |     |                          |                        |
++--------+------------------------------------+------------+-----+--------------------------+------------------------+
+| XX.2   | measurementTechniqueIdentifier     | O          | 0-1 | Identifier used to       | Free text, should be a |
+|        |                                    |            |     | identify the mesurment   | globally unique        |
+|        |                                    |            |     | technique                | identifier             |
++--------+------------------------------------+------------+-----+--------------------------+------------------------+
+| XX.2.1 | measurementTechniqueIdentifierType | O          | 1   | Type of the identifier   | Free text              |
++--------+------------------------------------+------------+-----+--------------------------+------------------------+
 
 
 Notes


### PR DESCRIPTION
Add `MeasurementTechnique` as a complex property having the subproperties `measurementTechniqueName`, `measurementTechniqueIdentifier` and `measurementTechniqueIdentifierType`. Close #67.

This proposal mimics what we already do for other properties allowing to link with PIDs, e.g. `Owner`, `Manufacturer`, `Model`, `InstrumentType`: a complex property having subproperties in the following way:

| ID     | Property                           | Obligation | Occ | Definition                                                                                                           | Allowed values, constraints, remarks              |
|--------|------------------------------------|------------|-----|----------------------------------------------------------------------------------------------------------------------|---------------------------------------------------|
| XX     | MeasurementTechnique               | R          | 0-n | The protocol that the instrument follows or the physical phenomenon it makes use of in order to make its observation |                                                   |
| XX.1   | measurementTechniqueName           | R          | 1   | Full name of the variable                                                                                            | Free text                                         |
| XX.2   | measurementTechniqueIdentifier     | O          | 0-1 | Identifier used to identify the measurement technique                                                                | Free text, should be a globally unique identifier |
| XX.2.1 | measurementTechniqueIdentifierType | O          | 1   | Type of the identifier                                                                                               | Free text                                         |

Note that the new property is added with the Id `XX` for the moment. This needs to be replaced with the actual Id that the property will get at the point of merging this pull request.