### PR TITLE
Add InstrumentStatus

### DIFF
--- a/schema.rst
+++ b/schema.rst
@@ -161,6 +161,14 @@ Metadata Schema for the Persistent Identification of Scientific Measuring Instru
 |       |                              |            |     | alternateIdentifierType  |                        |
 |       |                              |            |     | is Other.                |                        |
 +-------+------------------------------+------------+-----+--------------------------+------------------------+
+| XX    | InstrumentStatus             | O          | 0-1 | Current status of the    | Controlled list of     |
+|       |                              |            |     | instrument: whether it   | values:                |
+|       |                              |            |     | is active or not         |   Planning             |
+|       |                              |            |     |                          |   Commissioning        |
+|       |                              |            |     |                          |   Active               |
+|       |                              |            |     |                          |   Inactive             |
+|       |                              |            |     |                          |   Terminated           |
++-------+------------------------------+------------+-----+--------------------------+------------------------+
 
 Definition of terms in controlled lists of values
 -------------------------------------------------
@@ -319,6 +327,27 @@ alternateIdentifierType
 +-----------------+------------------------------------------------+
 | Other           | Any other kind of identifier                   |
 +-----------------+------------------------------------------------+
+
+InstrumentStatus
+................
+
++---------------+-------------------------------------------------+
+| Value         | Definition                                      |
++---------------+-------------------------------------------------+
+| Planning      | instrument in design or building phase, not yet |
+|               | active                                          |
++---------------+-------------------------------------------------+
+| Commissioning | instrument being tested or calibrated, before   |
+|               | regular operation                               |
++---------------+-------------------------------------------------+
+| Active        | instrument in use                               |
++---------------+-------------------------------------------------+
+| Inactive      | instrument not active, but could be reactivated |
+|               |                                                 |
++---------------+-------------------------------------------------+
+| Terminated    | instrument decommissioned, destroyed, lost or   |
+|               | terminated                                      |
++---------------+-------------------------------------------------+
 
 Notes
 -----


### PR DESCRIPTION
Add `InstrumentStatus` as a simple property with a controlled vocabulary with the values: `Planning`, `Commissioning`, `Active`, `Inactive`, and `Terminated`.  Close #58.

In detail, the proposal would be:
| ID | Property         | Obligation | Occ | Definition                                                    | Allowed values, constraints, remarks                                                       |
|----|------------------|------------|-----|---------------------------------------------------------------|--------------------------------------------------------------------------------------------|
| XX | InstrumentStatus | O          | 0-1 | Current status of the instrument: whether it is active or not | Controlled list of values: `Planning`, `Commissioning`, `Active`, `Inactive`, `Terminated` |

The definition of the values is:
| Value         | Definition                                                      |
|---------------|-----------------------------------------------------------------|
| Planning      | instrument in design or building phase, not yet active          |
| Commissioning | instrument being tested or calibrated, before regular operation |
| Active        | instrument in use                                               |
| Inactive      | instrument not active, but could be reactivated                 |
| Terminated    | instrument decommissioned, destroyed, lost or terminated        |

Note that the new property is added with the Id `XX` for the moment. This needs to be replaced with the actual Id that the property will get at the point of merging this pull request.