### PR TITLE
Add Subject

### DIFF
--- a/schema.rst
+++ b/schema.rst
@@ -161,6 +161,18 @@ Metadata Schema for the Persistent Identification of Scientific Measuring Instru
 |        |                                    |            |     | alternateIdentifierType  |                        |
 |        |                                    |            |     | is Other.                |                        |
 +--------+------------------------------------+------------+-----+--------------------------+------------------------+
+| XX     | Subject                            | O          | 0-n | Subject or keyword       |                        |
+|        |                                    |            |     | describing the           |                        |
+|        |                                    |            |     | instrument               |                        |
++--------+------------------------------------+------------+-----+--------------------------+------------------------+
+| XX.1   | subjectName                        | O          | 1   | Subject name or text     | Free text              |
++--------+------------------------------------+------------+-----+--------------------------+------------------------+
+| XX.2   | subjectIdentifier                  | O          | 0-1 | Identifier in the case   | Free text, should be a |
+|        |                                    |            |     | it refers to a term from | globally unique        |
+|        |                                    |            |     | an external vocabulary   | identifier             |
++--------+------------------------------------+------------+-----+--------------------------+------------------------+
+| XX.2.1 | subjectIdentifierType              | O          | 1   | Type of the identifier   | Free text              |
++--------+------------------------------------+------------+-----+--------------------------+------------------------+
 
 
 Notes

--- a/schema.rst
+++ b/schema.rst
@@ -192,17 +192,17 @@ Metadata Schema for the Persistent Identification of Scientific Measuring Instru
 +--------+------------------------------------+------------+-----+--------------------------+------------------------+
 | 15.2.1 | measuredQuantityIdentifierType     | O          | 1   | Type of the identifier   | Free text              |
 +--------+------------------------------------+------------+-----+--------------------------+------------------------+
-| XX     | Subject                            | O          | 0-n | Subject or keyword       |                        |
+| 16     | Subject                            | O          | 0-n | Subject or keyword       |                        |
 |        |                                    |            |     | describing the           |                        |
 |        |                                    |            |     | instrument               |                        |
 +--------+------------------------------------+------------+-----+--------------------------+------------------------+
-| XX.1   | subjectName                        | O          | 1   | Subject name or text     | Free text              |
+| 16.1   | subjectName                        | O          | 1   | Subject name or text     | Free text              |
 +--------+------------------------------------+------------+-----+--------------------------+------------------------+
-| XX.2   | subjectIdentifier                  | O          | 0-1 | Identifier in the case   | Free text, should be a |
+| 16.2   | subjectIdentifier                  | O          | 0-1 | Identifier in the case   | Free text, should be a |
 |        |                                    |            |     | it refers to a term from | globally unique        |
 |        |                                    |            |     | an external vocabulary   | identifier             |
 +--------+------------------------------------+------------+-----+--------------------------+------------------------+
-| XX.2.1 | subjectIdentifierType              | O          | 1   | Type of the identifier   | Free text              |
+| 16.2.1 | subjectIdentifierType              | O          | 1   | Type of the identifier   | Free text              |
 +--------+------------------------------------+------------+-----+--------------------------+------------------------+
 
 Definition of terms in controlled lists of values


### PR DESCRIPTION
Add `Subject` as an optional complex property having the subproperties `subjectName`, `subjectIdentifier` and `subjectIdentifierType`. Close #72.

This proposal mimics what we already do for other properties allowing to link with PIDs, e.g. `Owner`, `Manufacturer`, `Model`, `InstrumentType`: a complex property having subproperties in the following way:

| ID     | Property              | Obligation | Occ | Definition                                    | Allowed values, constraints, remarks              |
|--------|-----------------------|------------|-----|-----------------------------------------------|---------------------------------------------------|
| XX     | Subject               | O          | 0-n | Subject or keyword describing the instrument  |                                                   |
| XX.1   | subjectName           | O          | 1   | Subject name or text                          | Free text                                         |
| XX.2   | subjectIdentifier     | O          | 0-1 | Identifier in the case an external vocabulary | Free text, should be a globally unique identifier |
| XX.2.1 | subjectIdentifierType | O          | 1   | Type of the identifier                        | Free text                                         |

Note that the new property is added with the Id `XX` for the moment. This needs to be replaced with the actual Id that the property will get at the point of merging this pull request.