### PR TITLE
Add SWHID to controlled list of values for relatedIdentifierType

### DIFF
--- a/schema.rst
+++ b/schema.rst
@@ -116,8 +116,8 @@ Metadata Schema for the Persistent Identification of Scientific Measuring Instru
 |       |                              |            |     |                          |   Handle, IGSN, ISBN,  |
 |       |                              |            |     |                          |   ISSN, ISTC, LISSN,   |
 |       |                              |            |     |                          |   PMID, PURL, RAiD,    |
-|       |                              |            |     |                          |   RRID, UPC, URL,      |
-|       |                              |            |     |                          |   URN, w3id            |
+|       |                              |            |     |                          |   RRID, SWHID, UPC,    |
+|       |                              |            |     |                          |   URL, URN, w3id       |
 +-------+------------------------------+------------+-----+--------------------------+------------------------+
 | 12.2  | relationType                 | R          | 1   | Description of the       | Controlled list        |
 |       |                              |            |     | relationship             | of values:             |
@@ -235,6 +235,11 @@ relatedIdentifierType
 | RAiD    | Research Activity Identifier, see https://www.raid.org.au/  |
 +---------+-------------------------------------------------------------+
 | RRID    | Research Resource Identifiers, see https://www.rrids.org/   |
++---------+-------------------------------------------------------------+
+| SWHID   | SoftWare Hash IDentifiers are persistent, intrinsic         |
+|         | identifiers for software source code artifacts such as      |
+|         | source code files, source trees, commits, and other objects |
+|         | typically found in version control systems.                 |
 +---------+-------------------------------------------------------------+
 | UPC     | Universal Product Code is a barcode symbology used for      |
 |         | tracking trade items in stores.                             |


### PR DESCRIPTION
Add `SWHID` to controlled list of values for `relatedIdentifierType`. As a result, the definition of `relatedIdentifierType` reads as (the added value put in bold):
| ID   | Property              | Obligation | Occ | Definition             | Allowed values, constraints, remarks                                                       |
|------|-----------------------|------------|-----|------------------------|--------------------------------------------------------------------------------------------|
| 12.1 | relatedIdentifierType | R          | 1   | Type of the identifier | Controlled list of values: `ARK`, `arXiv`, `bibcode`, `DOI`, `EAN13`, `EISSN`, `Handle`, `IGSN`, `ISBN`, `ISSN`, `ISTC`, `LISSN`, `PMID`, `PURL`, `RAiD`, `RRID`, **`SWHID`**, `UPC`, `URL`, `URN`, `w3id` |

The corresponding line in the definition table for the values reads as:
| Value | Definition                                                      |
|-------|-----------------------------------------------------------------|
| SWHID | SoftWare Hash IDentifiers are persistent, intrinsic identifiers for software source code artifacts such as source code files, source trees, commits, and other objects typically found in version control systems. |

Close #82