### PR TITLE
Add a LinkML representation of the PIDINST 1.1 model.

### DIFF
--- a/support/README.rst
+++ b/support/README.rst
@@ -8,11 +8,16 @@ This includes:
 
 + pidinst-schema-1_0.schema.json: a JSON Schema representation.
 
++ pidinst-schema-1_1.yaml: a LinkML representation.
+
 + examples: examples of serializations of instrument metedata using
   the PIDINST schema.  Examples collected so far:
 
   - hzb-nanocluster.xml: NanoclusterTrap, an experimental station at
     HZB's electron storage ring BESSY II.
+
+  - hzb-nanocluster.json: Same, but using the JSON serialisation
+    defined by the aforementioned LinkML schema.
 
   - hzb-mx-14-1.xml, hzb-mx-14-1-pilatus.xml: Macromolecular
     Crystallography experimental station 14.1 at HZB's electron
@@ -28,5 +33,5 @@ represent instrument descriptions and the semantics of these
 properties.  It is technology agnostic and not limited to one
 particular serialization format.  The XML examples are just that:
 examples that illustrate how the schema could be implemented
-using XML.  The XML Schema Definition file and the JSON Schema
-representation are not authoritative.
+using XML.  The XML Schema Definition file, the JSON Schema
+representation, and the LinkML representation are not authoritative.

--- a/support/examples/hzb-nanocluster.json
+++ b/support/examples/hzb-nanocluster.json
@@ -1,0 +1,34 @@
+{
+  "identifier": "1234.1848",
+  "identifier_type": "Handle",
+  "schema_version": "1.1",
+  "landing_page": "https://www.helmholtz-berlin.de/pubbin/igama_output?modus=einzel&amp;sprache=en&amp;gid=1848&amp;typoid=35517",
+  "name": "NanoclusterTrap",
+  "owners": [
+  	{
+	  "name": "Helmholtz-Zentrum Berlin für Materialien und Energie",
+	  "identifier": "02aj13c28",
+	  "identifier_type": "ROR"
+	 }
+  ],
+  "manufacturers": [
+  	{
+	  "name": "Helmholtz-Zentrum Berlin für Materialien und Energie",
+	  "identifier": "02aj13c28",
+	  "identifier_type": "ROR"
+	}
+  ],
+  "types": [
+    {
+	  "name": "Synchrotron experimental station"
+	}
+  ],
+  "description": "The Nanocluster Trap endstation at BESSY II combines a cryogenic linear radio-frequency ion trap with an applied magnetic field for x-ray magnetic circular dichroism studies of cold and size-selected trapped ions. Applications include atomic, molecular, and cluster ions as well as ionic complexes.",
+  "related_identifiers": [
+    {
+	  "identifier": "10.17815/jlsrf-3-143",
+	  "type": "DOI",
+	  "relation": "IsDescribedBy"
+	}
+  ]
+}

--- a/support/pidinst-schema-1_1.yaml
+++ b/support/pidinst-schema-1_1.yaml
@@ -1,0 +1,619 @@
+id: https://example.invalid/pidinst
+name: pidinst
+title: Metadata Schema for the Persistent Identification of Instruments
+description: >-
+  A schema for the persistent identification of scientific instruments
+  by the institutions or bodies that use or manage them.
+conforms_to: https://doi.org/10.15497/RDA00070
+created_by: orcid:0000-0002-6095-8718
+contributors:
+  - orcid:0000-0002-1266-3819
+  - orcid:0000-0003-4163-9575
+  - orcid:0000-0003-3000-0020
+  - orcid:0000-0003-0870-3192
+  - orcid:0000-0001-5911-6022
+  - orcid:0000-0003-3585-6733
+  - orcid:0000-0001-5492-3212
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  orcid: https://orcid.org/
+  pidinst: https://example.invalid/pidinst/
+default_prefix: pidinst
+
+imports:
+  - linkml:types
+default_range: string
+
+
+classes:
+
+  PIDInstIsIdentifiableEntity:
+    description: >-
+      A mixin that represents any kind of identifiable entity, and that
+      contains the slots that are shared by all classes in this schema
+      intended to represent such entities.
+    notes:
+      - >-
+        The main purpose of having these slots in a shared mixin is to
+        be able to state once and for all the constraint that an
+        `identifier_type` must be present whenever an `identifier` is
+        present.
+    mixin: true
+    attributes:
+      name:
+        description: >-
+          The human-readable name of the entity.
+        required: true
+      identifier:
+        description: >-
+          An identifier (not necessarily human-readable) for the entity.
+        comments:
+          - >-
+            This is not an identifier in the LinkML sense of the term
+            – this is a string that identifies the entity, but without
+            the LinkML implications with respect to uniqueness or
+            inlining.
+      identifier_type:
+        description: >-
+          A value that indicates the type of identifier contained in the
+          `identifier` slot.
+    rules:
+      - description: >-
+          If the `identifier` is present, then the `identifier_type`
+          must be present as well.
+      - preconditions:
+          slot_conditions:
+            identifier:
+              required: true
+        postconditions:
+          slot_conditions:
+            identifier_type:
+              required: true
+
+  PIDInstInstrument:
+    description: >-
+      A research instrument. This is the main class of the PIDInst
+      model.
+    mixins:
+      - PIDInstIsIdentifiableEntity
+    attributes:
+      schema_version:
+        description: >-
+          The version of the PIDInst model this record conforms to.
+        conforms_to: PIDInst model property ID 2
+        range: PIDInstVersion
+        required: true
+      landing_page:
+        description: >-
+          A landing page that the identifier resolves to.
+        conforms_to: PIDInst model property ID 3
+        range: uri
+        required: true
+      owners:
+        description: >-
+          The institution(s) responsible for the management of the
+          instrument. This may include the legal owner, the operator, or
+          an institute providing access to the instrument.
+        conforms_to: PIDINST model property ID 5
+        range: PIDInstOwner
+        multivalued: true
+        required: true
+      manufacturers:
+        description: >-
+          The instrument’s manufacturer(s) or developer. This may also
+          be the owner for custom built instruments.
+        conforms_to: PIDINST model property ID 6
+        range: PIDInstManufacturer
+        multivalued: true
+        required: true
+      model:
+        description: >-
+          The model or type of device, as attributed by the manufacturer.
+        conforms_to: PIDINST model property ID 7
+        range: PIDInstModel
+        recommended: true
+      description:
+        description: >-
+          A technical description of the device and its capabilities.
+        conforms_to: PIDINST model property ID 8
+        recommended: true
+      types:
+        description: >-
+          The type(s) the instrument can be classified into.
+        conforms_to: PIDINST model property ID 9
+        range: PIDInstInstrumentType
+        multivalued: true
+        recommended: true
+      measured_variables:
+        description: >-
+          The variable(s) that this instrument measures or observes.
+        conforms_to: PIDINST model property ID 10
+        multivalued: true
+        deprecated: Deprecated in favor of `measured_quantities`.
+      dates:
+        description: >-
+          Dates that are relevant to the instrument.
+        conforms_to: PIDINST model property ID 11
+        range: PIDInstDate
+        multivalued: true
+        recommended: true
+      related_identifiers:
+        description: >-
+          Identifiers of resources that are related to the instrument.
+        comments:
+          - >-
+            Not to be confused with `alternate_identifiers`, which is
+            intended for other identifiers for the very same instrument.
+        conforms_to: PIDINST model property ID 12
+        range: PIDInstRelatedIdentifier
+        multivalued: true
+        recommended: true
+      alternate_identifiers:
+        description: >-
+          Identifiers (other than the PIDInst identifier itself)
+          pertaining to the same instrument instance. This should be
+          used if the instrument has a serial number. Other possible
+          uses include an owner’s inventory number or an entry in some
+          instrument database.
+        comments:
+          - >-
+            Not to be confused with `related_identifiers`, which is
+            intended for identifiers pointing to other resources that
+            are merely related to this instrument instance while being
+            distinct from it.
+        conforms_to: PIDINST model property ID 13
+        range: PIDInstAlternateIdentifier
+        multivalued: true
+        recommended: true
+      measured_quantities:
+        description: >-
+          The variable(s) that this instrument measures or observes.
+        conforms_to: PIDINST model property ID 15
+        instantiates:
+          - pidinst:PIDInstVersionable
+        annotations:
+          added_in: "1.1"
+        range: PIDInstMeasuredQuantity
+        multivalued: true
+        recommended: true
+      measurement_techniques:
+        description: >-
+          The protocol(s) that the instrument follows or the physical
+          phenomenon it makes use of in order to make its observations.
+        conforms_to: PIDINST model property ID 14
+        instantiates:
+          - pidinst:PIDInstVersionable
+        annotations:
+          added_in: "1.1"
+        range: PIDInstMeasurementTechnique
+        multivalued: true
+        recommended: true
+      subjects:
+        description: >-
+          Subjects or keywords describing the instrument.
+        conforms_to: PIDINST model property ID 16
+        instantiates:
+          - pidinst:PIDInstVersionable
+        annotations:
+          added_in: "1.1"
+        range: PIDInstSubject
+        multivalued: true
+    slot_usage:
+      name:
+        description: >-
+          The name by which the instrument instance is known.
+        conforms_to: PIDINST model property ID 4
+      identifier:
+        description: >-
+          A string that uniquely identifies the instrument instance.
+        notes:
+          - >-
+            In this class (and in this class only) the `identifier`
+            attribute is a real identifier in the LinkML sense of the
+            term.
+        conforms_to: PIDINST model property ID 1
+        identifier: true
+      identifier_type:
+        conforms_to: PIDINST model property ID 1.1
+    tree_root: true
+    extra_slots:
+      allowed: true
+
+  PIDInstOwner:
+    description: >-
+      An institution responsible for the management of an instrument.
+      This may include the legal owner, the operator, or an institute
+      providing access to the instrument.
+    mixins:
+      - PIDInstIsIdentifiableEntity
+    attributes:
+      contact:
+        description: >-
+          Contact address of the owner.
+        conforms_to: PIDINST model property ID 5.2
+    slot_usage:
+      name:
+        conforms_to: PIDINST model property 5.1
+      identifier:
+        conforms_to: PIDINST model property 5.3
+      identifier_type:
+        conforms_to: PIDINST model property 5.3.1
+
+  PIDInstManufacturer:
+    description: >-
+      The manufacturer of an instrument.
+    mixins:
+      - PIDInstIsIdentifiableEntity
+    slot_usage:
+      name:
+        conforms_to: PIDINST model property ID 6.1
+      identifier:
+        conforms_to: PIDINST model property ID 6.2
+      identifier_type:
+        conforms_to: PIDINST model property ID 6.2.1
+
+  PIDInstModel:
+    description: >-
+      The model of an instrument.
+    mixins:
+      - PIDInstIsIdentifiableEntity
+    slot_usage:
+      name:
+        conforms_to: PIDINST model property ID 7.1
+      identifier:
+        conforms_to: PIDINST model property ID 7.2
+      identifier_type:
+        conforms_to: PIDINST model property ID 7.2.1
+
+  PIDInstInstrumentType:
+    description: >-
+      The type of an instrument.
+
+      This differs from the instrument model in that (1) it may not be
+      assigned by the manufacturer, and (2) a single instrument can be
+      of more than one type.
+    mixins:
+      - PIDInstIsIdentifiableEntity
+    slot_usage:
+      name:
+        conforms_to: PIDINST model property ID 9.1
+      identifier:
+        conforms_to: PIDINST model property ID 9.2
+      identifier_type:
+        conforms_to: PIDINST model property ID 9.2.1
+
+  PIDInstDate:
+    description: >-
+      A date relevant to an instrument.
+    attributes:
+      date:
+        description: >-
+          The date itself.
+        range: date
+        required: true
+      type:
+        description: >-
+          The type of date, indicating how the date is relevant to the
+          instrument.
+        conforms_to: PIDINST model property ID 11.1
+        range: PIDInstDateType
+        required: true
+
+  PIDInstRelatedIdentifier:
+    description: >-
+      An identifier for a resource related to an instrument.
+    attributes:
+      identifier:
+        description: >-
+          The identifier itself.
+        required: true
+      name:
+        description: >-
+          A name for the related resource. This may be used to give an
+          hint on the content of that resource.
+        conforms_to: PIDINST model property ID 12.3
+      type:
+        description: >-
+          The type of the identifier.
+        comments:
+          - >-
+            Contrary to most other “identifier type” attributes in this
+            schema, this one is _not_ free text and is instead
+            constrained to a fixed list of values.
+        conforms_to: PIDINST model property ID 12.1
+        range: PIDInstRelatedIdentifierType
+        required: true
+      relation:
+        description: >-
+          A description of the relationship between an instrument and
+          the related resource pointed to by the identifier.
+        conforms_to: PIDINST model property ID 12.2
+        range: PIDInstRelationType
+        required: true
+
+  PIDInstAlternateIdentifier:
+    description: >-
+      A non-PIDInst identifier that can also identify an instrument
+      instance.
+    attributes:
+      identifier:
+        description: >-
+          The identifier itself.
+        required: true
+      type:
+        description:
+          The type of the alternate identifier.
+        comments:
+          - >-
+            Contrary to most other “identifier type” attributes in this
+            schema, this one is _not_ free text and is instead
+            constrained to a fixed list of values.
+        conforms_to: PIDINST model property ID 13.1
+        range: PIDInstAlternateIdentifierType
+        required: true
+      name:
+        description: >-
+          A supplementary name for the identifier type. This is mostly
+          useful if `type` is set to `Other`.
+        conforms_to: PIDINST model property ID 13.2
+
+  PIDInstMeasurementTechnique:
+    description: >-
+      The protocol that the instrument follows or the physical
+      phenomenon it makes use of in order to make its observations.
+    instantiates:
+      - pidinst:PIDInstVersionable
+    annotations:
+      added_in: "1.1"
+    mixins:
+      - PIDInstIsIdentifiableEntity
+    slot_usage:
+      name:
+        conforms_to: PIDINST model property ID 14.1
+      identifier:
+        conforms_to: PIDINST model property ID 14.2
+      identifier_type:
+        conforms_to: PIDINST model property ID 14.2.1
+
+  PIDInstMeasuredQuantity:
+    description: >-
+      A variable that an instrument measures or observes.
+    instantiates:
+      - pidinst:PIDInstVersionable
+    annotations:
+      added_in: "1.1"
+    mixins:
+      - PIDInstIsIdentifiableEntity
+    slot_usage:
+      name:
+        conforms_to: PIDINST model property ID 15.1
+      identifier:
+        conforms_to: PIDINST model property ID 15.2
+      identifier_type:
+        conforms_to: PIDINST model property ID 15.2.1
+
+  PIDInstSubject:
+    description: >-
+      A subject or keyword describing the instrument.
+    instantiates:
+      - pidinst:PIDInstVersionable
+    annotations:
+      added_in: "1.1"
+    mixins:
+      - PIDInstIsIdentifiableEntity
+    slot_usage:
+      name:
+        conforms_to: PIDINST model property ID 16.1
+      identifier:
+        conforms_to: PIDINST model property ID 16.2
+      identifier_type:
+        conforms_to: PIDINST model property ID 16.2.1
+
+  PIDInstVersionable:
+    description: >-
+      A LinkML metamodel extension class to describe attributes that may
+      not exist in all versions of the schema.
+    attributes:
+      added_in:
+        description: >-
+          The version of the PIDINST schema in which the attribute was
+          added. If not specified, the attribute is assumed to have been
+          present since version 1.0.
+        range: PIDInstVersion
+
+
+enums:
+
+  PIDInstVersion:
+    description: >-
+      Available versions of the PIDInst model.
+    permissible_values:
+      "1.0":
+      "1.1":
+
+  PIDInstDateType:
+    description: >-
+      Values describing how a date is relevant to an instrument.
+    permissible_values:
+      Commissioned:
+        description: >-
+          The date when the instrument started to be in operation.
+      DeComissioned:
+        description: >-
+          The date when the instrument ceased to be in operation.
+
+  PIDInstRelatedIdentifierType:
+    description: >-
+      Possible types of related identifiers for an instrument.
+    permissible_values:
+      ARK:
+        description: >-
+          Archival Resource Key, a URI designed to support long-term
+          access to information objects.
+      arXiv:
+        description: >-
+          An arXiv.org identifier. arXiv.org is a repository of
+          preprints of scientific papers in the fields of mathematics,
+          physics, astronomy, computer science, quantitative biology,
+          and quantitative finance.
+      bibcode:
+        description: >-
+          Astrophysics Data System bibliographic code. A standardized
+          19-character identifier.
+      DOI:
+        description: >-
+          Digital Object Identifier. A character string used to uniquely
+          identify an object. A DOI is divided into two parts, a prefix
+          and a suffix, separated by a slash.
+      EAN13:
+        description: >-
+          European Article Number, now renamed International Article
+          Number but retaining the original acronym, is a 13-digit
+          barcoding standard that is a superset of the original 12-digit
+          Universal Product Code (UPC) system.
+      EISSN:
+        description: >-
+          Electronic International Standard Serial Number. Used to
+          identify periodicals in electronic form (eISSN or e-ISSN).
+      Handle:
+        description: >-
+          This refers specifically to an ID in the Handle system
+          operated by the Corporation for National Research Initiatives
+          (CNRI).
+      IGSN:
+        description: >-
+          A persistent unique identifier for physical samples and
+          specimens.
+        see_also:
+          - https://www.igsn.org/
+      ISBN:
+        description: >-
+          International Standard Book Number. A unique numeric book
+          identifier.
+      ISSN:
+        description: >-
+          International Standard Serial Number. A unique 8-digit number
+          used to identify a print or electronic periodical publication.
+      ISTC:
+        description: >-
+          International Standard text Code. A unique “number” assgned to
+          a textual work. An ISTC consists of 16 numbers and/or letters.
+      LISSN:
+        description: >-
+          The Linking ISSN or ISSN-L enables collocation or linking
+          among different media versions of a continuing resource.
+      PMID:
+        description: >-
+          PubMed identifier. A unique number assigned to each PubMed
+          record.
+      PURL:
+        description: >-
+          Permanent Uniform Resource Locator.
+      RAiD:
+        description: >-
+          Research Activity Identifier.
+        see_also:
+          - https://www.raid.org.au/
+      RRID:
+        description: >-
+          Research Resource Identifier.
+        see_also:
+          - https://www.rrids.org/
+      SWHID:
+        description: >-
+          SoftWare Hash IDentifiers are persistent, intrinsic
+          identifiers for software source code artifacts such as source
+          code files, source trees, commits, and other objects typically
+          found in version control systems.
+      UPC:
+        description: >-
+          Universal Product Code is a barcode symbology used for
+          tracking trade idems in store.
+      URL:
+        description: >-
+          Uniform Resource Locator, also known as web address.
+      URN:
+        description: >-
+          Uniform Resource Name. A unique and persistent identifier of
+          an electronic document.
+      w3id:
+        description: >-
+          Permanent identifier for Web applications. Mostly used to
+          publish vocabularies and ontologies.
+
+  PIDInstRelationType:
+    description: >-
+      Possible types of relation between a PIDInst instance and its
+      related identifiers.
+    permissible_values:
+      IsDescribedBy:
+        description: >-
+          The lined resource is a document describing the instrument.
+      IsNewVersionOf:
+        description: >-
+          If an instrument is substantially modified, a new PID may be
+          attributed to the new version. In that case the old and the
+          new PID should be linked to each other. `IsNewVersionOf`
+          should be used in the new PID record to link the old
+          instrument before the modification.
+      IsPreviousVersionOf:
+        description: >-
+          If an instrument is substantially modified, a new PID may be
+          attributed to the new version. In that case the old and the
+          new PID should be linked to each other. `IsPreviousVersionOf`
+          should be used in the old PID record to link the new
+          instrument after the modification.
+      HasComponent:
+        description: >-
+          In the case of a complex instrument, having multiple
+          components that may be considered as instruments in their own
+          right, with their own PIDs, these PIDs should be linked.
+          `HasComponent` should be used in the PID record of the
+          compound instrument to link the components.
+      IsComponentOf:
+        description: >-
+          In the case of a complex instrument, having multiple
+          components that may be considered as instruments in their own
+          right, with their own PIDs, these PIDs should be linked.
+          `IsComponentOf` should be used in the PID records of the
+          components to link the compound instrument.
+      References:
+        description: >-
+          This may be used in the generic case, if no other more
+          specific relation type applies.
+      HasMetadata:
+        description: >-
+          If there is additional metadata describing the instrument,
+          possibly using a community specific metadata standard, that
+          metadata record may be linked using `HasMetadata`.
+      WasUsedIn:
+        description: >-
+          If the instrument has been deployed in some research activity,
+          such as a cruise of a research vessel, `WasUsedIn` may be used
+          to link that activity.
+      IsIdenticalTo:
+        description: >-
+          If multiple PIDs have been attributed to a single instrument
+          (which should preferably be avoided in the first place), these
+          PID records should be linked to each other using
+          `IsIdenticalTo`.
+      IsAttachedTo:
+        description: >-
+          If the instrument is permanently attached to another
+          instrument, the PID record for both instruments should link to
+          each other using `IsAttachedTo`.
+
+  PIDInstAlternateIdentifierType:
+    description: >-
+      Possible types of alternate identifiers for a PIDINST instance.
+    permissible_values:
+      SerialNumber:
+        description: >-
+          A serial number attributed by the manufacturer.
+      InventoryNumber:
+        description: >-
+          An inventory number used by the owner.
+      Other:
+        description: >-
+          Any other kind of identifier.

--- a/support/pidinst-schema-1_1.yaml
+++ b/support/pidinst-schema-1_1.yaml
@@ -2,8 +2,8 @@ id: https://example.invalid/pidinst
 name: pidinst
 title: Metadata Schema for the Persistent Identification of Instruments
 description: >-
-  A schema for the persistent identification of scientific instruments
-  by the institutions or bodies that use or manage them.
+  A schema for the persistent identification of scientific instruments by the
+  institutions or bodies that use or manage them.
 conforms_to: https://doi.org/10.15497/RDA00070
 created_by: orcid:0000-0002-6095-8718
 contributors:
@@ -25,43 +25,44 @@ imports:
   - linkml:types
 default_range: string
 
-
 classes:
+  PIDInstObjectMixin:
+    description: A mixin used by all objects defined in this schema.
+    notes:
+      - This mixin is intended to facilitate customization of this schema, by
+        allowing another schema to (i) import the present schema and (ii)
+        redefine this mixin as needed.
+    mixin: true
 
   PIDInstIsIdentifiableEntity:
-    description: >-
-      A mixin that represents any kind of identifiable entity, and that
-      contains the slots that are shared by all classes in this schema
-      intended to represent such entities.
+    description:
+      A mixin that represents any kind of identifiable entity, and that contains
+      the slots that are shared by all classes in this schema intended to
+      represent such entities.
     notes:
-      - >-
-        The main purpose of having these slots in a shared mixin is to
-        be able to state once and for all the constraint that an
-        `identifier_type` must be present whenever an `identifier` is
-        present.
+      - The main purpose of having these slots in a shared mixin is to be able
+        to state once and for all the constraint that an `identifier_type` must
+        be present whenever an `identifier` is present.
     mixin: true
     attributes:
       name:
-        description: >-
-          The human-readable name of the entity.
+        description: The human-readable name of the entity.
         required: true
       identifier:
-        description: >-
+        description:
           An identifier (not necessarily human-readable) for the entity.
         comments:
-          - >-
-            This is not an identifier in the LinkML sense of the term
-            – this is a string that identifies the entity, but without
-            the LinkML implications with respect to uniqueness or
-            inlining.
+          - This is not an identifier in the LinkML sense of the term – this is
+            a string that identifies the entity, but without the LinkML
+            implications with respect to uniqueness or inlining.
       identifier_type:
-        description: >-
+        description:
           A value that indicates the type of identifier contained in the
           `identifier` slot.
     rules:
-      - description: >-
-          If the `identifier` is present, then the `identifier_type`
-          must be present as well.
+      - description:
+          If the `identifier` is present, then the `identifier_type` must be
+          present as well.
       - preconditions:
           slot_conditions:
             identifier:
@@ -72,103 +73,92 @@ classes:
               required: true
 
   PIDInstInstrument:
-    description: >-
-      A research instrument. This is the main class of the PIDInst
-      model.
+    description:
+      A research instrument. This is the main class of the PIDInst model.
     mixins:
       - PIDInstIsIdentifiableEntity
+      - PIDInstObjectMixin
     attributes:
       schema_version:
-        description: >-
-          The version of the PIDInst model this record conforms to.
+        description: The version of the PIDInst model this record conforms to.
         conforms_to: PIDInst model property ID 2
         range: PIDInstVersion
         required: true
       landing_page:
-        description: >-
-          A landing page that the identifier resolves to.
+        description: A landing page that the identifier resolves to.
         conforms_to: PIDInst model property ID 3
         range: uri
         required: true
       owners:
-        description: >-
-          The institution(s) responsible for the management of the
-          instrument. This may include the legal owner, the operator, or
-          an institute providing access to the instrument.
+        description:
+          The institution(s) responsible for the management of the instrument.
+          This may include the legal owner, the operator, or an institute
+          providing access to the instrument.
         conforms_to: PIDINST model property ID 5
         range: PIDInstOwner
         multivalued: true
         required: true
       manufacturers:
-        description: >-
-          The instrument’s manufacturer(s) or developer. This may also
-          be the owner for custom built instruments.
+        description:
+          The instrument’s manufacturer(s) or developer. This may also be the
+          owner for custom built instruments.
         conforms_to: PIDINST model property ID 6
         range: PIDInstManufacturer
         multivalued: true
         required: true
       model:
-        description: >-
+        description:
           The model or type of device, as attributed by the manufacturer.
         conforms_to: PIDINST model property ID 7
         range: PIDInstModel
         recommended: true
       description:
-        description: >-
-          A technical description of the device and its capabilities.
+        description: A technical description of the device and its capabilities.
         conforms_to: PIDINST model property ID 8
         recommended: true
       types:
-        description: >-
-          The type(s) the instrument can be classified into.
+        description: The type(s) the instrument can be classified into.
         conforms_to: PIDINST model property ID 9
         range: PIDInstInstrumentType
         multivalued: true
         recommended: true
       measured_variables:
-        description: >-
-          The variable(s) that this instrument measures or observes.
+        description: The variable(s) that this instrument measures or observes.
         conforms_to: PIDINST model property ID 10
         multivalued: true
         deprecated: Deprecated in favor of `measured_quantities`.
       dates:
-        description: >-
-          Dates that are relevant to the instrument.
+        description: Dates that are relevant to the instrument.
         conforms_to: PIDINST model property ID 11
         range: PIDInstDate
         multivalued: true
         recommended: true
       related_identifiers:
-        description: >-
+        description:
           Identifiers of resources that are related to the instrument.
         comments:
-          - >-
-            Not to be confused with `alternate_identifiers`, which is
-            intended for other identifiers for the very same instrument.
+          - Not to be confused with `alternate_identifiers`, which is intended
+            for other identifiers for the very same instrument.
         conforms_to: PIDINST model property ID 12
         range: PIDInstRelatedIdentifier
         multivalued: true
         recommended: true
       alternate_identifiers:
-        description: >-
-          Identifiers (other than the PIDInst identifier itself)
-          pertaining to the same instrument instance. This should be
-          used if the instrument has a serial number. Other possible
-          uses include an owner’s inventory number or an entry in some
-          instrument database.
+        description:
+          Identifiers (other than the PIDInst identifier itself) pertaining to
+          the same instrument instance. This should be used if the instrument
+          has a serial number. Other possible uses include an owner’s inventory
+          number or an entry in some instrument database.
         comments:
-          - >-
-            Not to be confused with `related_identifiers`, which is
-            intended for identifiers pointing to other resources that
-            are merely related to this instrument instance while being
-            distinct from it.
+          - Not to be confused with `related_identifiers`, which is intended for
+            identifiers pointing to other resources that are merely related to
+            this instrument instance while being distinct from it.
         conforms_to: PIDINST model property ID 13
         range: PIDInstAlternateIdentifier
         multivalued: true
         recommended: true
       measured_quantities:
-        description: >-
-          The variable(s) that this instrument measures or observes.
+        description: The variable(s) that this instrument measures or observes.
         conforms_to: PIDINST model property ID 15
         instantiates:
           - pidinst:PIDInstVersionable
@@ -178,9 +168,9 @@ classes:
         multivalued: true
         recommended: true
       measurement_techniques:
-        description: >-
-          The protocol(s) that the instrument follows or the physical
-          phenomenon it makes use of in order to make its observations.
+        description:
+          The protocol(s) that the instrument follows or the physical phenomenon
+          it makes use of in order to make its observations.
         conforms_to: PIDINST model property ID 14
         instantiates:
           - pidinst:PIDInstVersionable
@@ -190,8 +180,7 @@ classes:
         multivalued: true
         recommended: true
       subjects:
-        description: >-
-          Subjects or keywords describing the instrument.
+        description: Subjects or keywords describing the instrument.
         conforms_to: PIDINST model property ID 16
         instantiates:
           - pidinst:PIDInstVersionable
@@ -201,17 +190,13 @@ classes:
         multivalued: true
     slot_usage:
       name:
-        description: >-
-          The name by which the instrument instance is known.
+        description: The name by which the instrument instance is known.
         conforms_to: PIDINST model property ID 4
       identifier:
-        description: >-
-          A string that uniquely identifies the instrument instance.
+        description: A string that uniquely identifies the instrument instance.
         notes:
-          - >-
-            In this class (and in this class only) the `identifier`
-            attribute is a real identifier in the LinkML sense of the
-            term.
+          - In this class (and in this class only) the `identifier` attribute is
+            a real identifier in the LinkML sense of the term.
         conforms_to: PIDINST model property ID 1
         identifier: true
       identifier_type:
@@ -221,16 +206,16 @@ classes:
       allowed: true
 
   PIDInstOwner:
-    description: >-
-      An institution responsible for the management of an instrument.
-      This may include the legal owner, the operator, or an institute
-      providing access to the instrument.
+    description:
+      An institution responsible for the management of an instrument. This may
+      include the legal owner, the operator, or an institute providing access to
+      the instrument.
     mixins:
       - PIDInstIsIdentifiableEntity
+      - PIDInstObjectMixin
     attributes:
       contact:
-        description: >-
-          Contact address of the owner.
+        description: Contact address of the owner.
         conforms_to: PIDINST model property ID 5.2
     slot_usage:
       name:
@@ -241,10 +226,10 @@ classes:
         conforms_to: PIDINST model property 5.3.1
 
   PIDInstManufacturer:
-    description: >-
-      The manufacturer of an instrument.
+    description: The manufacturer of an instrument.
     mixins:
       - PIDInstIsIdentifiableEntity
+      - PIDInstObjectMixin
     slot_usage:
       name:
         conforms_to: PIDINST model property ID 6.1
@@ -254,10 +239,10 @@ classes:
         conforms_to: PIDINST model property ID 6.2.1
 
   PIDInstModel:
-    description: >-
-      The model of an instrument.
+    description: The model of an instrument.
     mixins:
       - PIDInstIsIdentifiableEntity
+      - PIDInstObjectMixin
     slot_usage:
       name:
         conforms_to: PIDINST model property ID 7.1
@@ -267,14 +252,14 @@ classes:
         conforms_to: PIDINST model property ID 7.2.1
 
   PIDInstInstrumentType:
-    description: >-
-      The type of an instrument.
+    description: The type of an instrument.
 
-      This differs from the instrument model in that (1) it may not be
-      assigned by the manufacturer, and (2) a single instrument can be
-      of more than one type.
+      This differs from the instrument model in that (1) it may not be assigned
+      by the manufacturer, and (2) a single instrument can be of more than one
+      type.
     mixins:
       - PIDInstIsIdentifiableEntity
+      - PIDInstObjectMixin
     slot_usage:
       name:
         conforms_to: PIDINST model property ID 9.1
@@ -284,16 +269,21 @@ classes:
         conforms_to: PIDINST model property ID 9.2.1
 
   PIDInstDate:
-    description: >-
-      A date relevant to an instrument.
+    description: A date relevant to an instrument.
+    mixins:
+      - PIDInstObjectMixin
     attributes:
-      date:
-        description: >-
-          The date itself.
+      value:
+        description: The date itself.
+        notes:
+          - The slot is named `value` rather than `date` because of a bug in
+            LinkML-Py’s Pydantic code generator.
+        see_also:
+          - https://github.com/linkml/linkml/issues/3376
         range: date
         required: true
       type:
-        description: >-
+        description:
           The type of date, indicating how the date is relevant to the
           instrument.
         conforms_to: PIDINST model property ID 11.1
@@ -301,73 +291,70 @@ classes:
         required: true
 
   PIDInstRelatedIdentifier:
-    description: >-
-      An identifier for a resource related to an instrument.
+    description: An identifier for a resource related to an instrument.
+    mixins:
+      - PIDInstObjectMixin
     attributes:
       identifier:
-        description: >-
-          The identifier itself.
+        description: The identifier itself.
         required: true
       name:
-        description: >-
-          A name for the related resource. This may be used to give an
-          hint on the content of that resource.
+        description:
+          A name for the related resource. This may be used to give an hint on
+          the content of that resource.
         conforms_to: PIDINST model property ID 12.3
       type:
-        description: >-
-          The type of the identifier.
+        description: The type of the identifier.
         comments:
-          - >-
-            Contrary to most other “identifier type” attributes in this
-            schema, this one is _not_ free text and is instead
-            constrained to a fixed list of values.
+          - Contrary to most other “identifier type” attributes in this schema,
+            this one is _not_ free text and is instead constrained to a fixed
+            list of values.
         conforms_to: PIDINST model property ID 12.1
         range: PIDInstRelatedIdentifierType
         required: true
       relation:
-        description: >-
-          A description of the relationship between an instrument and
-          the related resource pointed to by the identifier.
+        description:
+          A description of the relationship between an instrument and the
+          related resource pointed to by the identifier.
         conforms_to: PIDINST model property ID 12.2
         range: PIDInstRelationType
         required: true
 
   PIDInstAlternateIdentifier:
-    description: >-
-      A non-PIDInst identifier that can also identify an instrument
-      instance.
+    description:
+      A non-PIDInst identifier that can also identify an instrument instance.
+    mixins:
+      - PIDInstObjectMixin
     attributes:
       identifier:
-        description: >-
-          The identifier itself.
+        description: The identifier itself.
         required: true
       type:
-        description:
-          The type of the alternate identifier.
+        description: The type of the alternate identifier.
         comments:
-          - >-
-            Contrary to most other “identifier type” attributes in this
-            schema, this one is _not_ free text and is instead
-            constrained to a fixed list of values.
+          - Contrary to most other “identifier type” attributes in this schema,
+            this one is _not_ free text and is instead constrained to a fixed
+            list of values.
         conforms_to: PIDINST model property ID 13.1
         range: PIDInstAlternateIdentifierType
         required: true
       name:
-        description: >-
-          A supplementary name for the identifier type. This is mostly
-          useful if `type` is set to `Other`.
+        description:
+          A supplementary name for the identifier type. This is mostly useful if
+          `type` is set to `Other`.
         conforms_to: PIDINST model property ID 13.2
 
   PIDInstMeasurementTechnique:
-    description: >-
-      The protocol that the instrument follows or the physical
-      phenomenon it makes use of in order to make its observations.
+    description:
+      The protocol that the instrument follows or the physical phenomenon it
+      makes use of in order to make its observations.
     instantiates:
       - pidinst:PIDInstVersionable
     annotations:
       added_in: "1.1"
     mixins:
       - PIDInstIsIdentifiableEntity
+      - PIDInstObjectMixin
     slot_usage:
       name:
         conforms_to: PIDINST model property ID 14.1
@@ -377,14 +364,14 @@ classes:
         conforms_to: PIDINST model property ID 14.2.1
 
   PIDInstMeasuredQuantity:
-    description: >-
-      A variable that an instrument measures or observes.
+    description: A variable that an instrument measures or observes.
     instantiates:
       - pidinst:PIDInstVersionable
     annotations:
       added_in: "1.1"
     mixins:
       - PIDInstIsIdentifiableEntity
+      - PIDInstObjectMixin
     slot_usage:
       name:
         conforms_to: PIDINST model property ID 15.1
@@ -394,14 +381,14 @@ classes:
         conforms_to: PIDINST model property ID 15.2.1
 
   PIDInstSubject:
-    description: >-
-      A subject or keyword describing the instrument.
+    description: A subject or keyword describing the instrument.
     instantiates:
       - pidinst:PIDInstVersionable
     annotations:
       added_in: "1.1"
     mixins:
       - PIDInstIsIdentifiableEntity
+      - PIDInstObjectMixin
     slot_usage:
       name:
         conforms_to: PIDINST model property ID 16.1
@@ -411,209 +398,186 @@ classes:
         conforms_to: PIDINST model property ID 16.2.1
 
   PIDInstVersionable:
-    description: >-
-      A LinkML metamodel extension class to describe attributes that may
-      not exist in all versions of the schema.
+    description:
+      A LinkML metamodel extension class to describe attributes that may not
+      exist in all versions of the schema.
     attributes:
       added_in:
-        description: >-
-          The version of the PIDINST schema in which the attribute was
-          added. If not specified, the attribute is assumed to have been
-          present since version 1.0.
+        description:
+          The version of the PIDINST schema in which the attribute was added. If
+          not specified, the attribute is assumed to have been present since
+          version 1.0.
         range: PIDInstVersion
 
-
 enums:
-
   PIDInstVersion:
-    description: >-
-      Available versions of the PIDInst model.
+    description: Available versions of the PIDInst model.
     permissible_values:
       "1.0":
+        title: Version 1 0
       "1.1":
+        title: Version 1 1
 
   PIDInstDateType:
-    description: >-
-      Values describing how a date is relevant to an instrument.
+    description: Values describing how a date is relevant to an instrument.
     permissible_values:
       Commissioned:
-        description: >-
-          The date when the instrument started to be in operation.
+        description: The date when the instrument started to be in operation.
       DeComissioned:
-        description: >-
-          The date when the instrument ceased to be in operation.
+        description: The date when the instrument ceased to be in operation.
 
   PIDInstRelatedIdentifierType:
-    description: >-
-      Possible types of related identifiers for an instrument.
+    description: Possible types of related identifiers for an instrument.
     permissible_values:
       ARK:
-        description: >-
-          Archival Resource Key, a URI designed to support long-term
-          access to information objects.
+        description:
+          Archival Resource Key, a URI designed to support long-term access to
+          information objects.
       arXiv:
-        description: >-
-          An arXiv.org identifier. arXiv.org is a repository of
-          preprints of scientific papers in the fields of mathematics,
-          physics, astronomy, computer science, quantitative biology,
-          and quantitative finance.
+        description:
+          An arXiv.org identifier. arXiv.org is a repository of preprints of
+          scientific papers in the fields of mathematics, physics, astronomy,
+          computer science, quantitative biology, and quantitative finance.
       bibcode:
-        description: >-
+        description:
           Astrophysics Data System bibliographic code. A standardized
           19-character identifier.
       DOI:
-        description: >-
+        description:
           Digital Object Identifier. A character string used to uniquely
-          identify an object. A DOI is divided into two parts, a prefix
-          and a suffix, separated by a slash.
+          identify an object. A DOI is divided into two parts, a prefix and a
+          suffix, separated by a slash.
       EAN13:
-        description: >-
-          European Article Number, now renamed International Article
-          Number but retaining the original acronym, is a 13-digit
-          barcoding standard that is a superset of the original 12-digit
-          Universal Product Code (UPC) system.
+        description:
+          European Article Number, now renamed International Article Number but
+          retaining the original acronym, is a 13-digit barcoding standard that
+          is a superset of the original 12-digit Universal Product Code (UPC)
+          system.
       EISSN:
-        description: >-
-          Electronic International Standard Serial Number. Used to
-          identify periodicals in electronic form (eISSN or e-ISSN).
+        description:
+          Electronic International Standard Serial Number. Used to identify
+          periodicals in electronic form (eISSN or e-ISSN).
       Handle:
-        description: >-
-          This refers specifically to an ID in the Handle system
-          operated by the Corporation for National Research Initiatives
-          (CNRI).
+        description:
+          This refers specifically to an ID in the Handle system operated by the
+          Corporation for National Research Initiatives (CNRI).
       IGSN:
-        description: >-
-          A persistent unique identifier for physical samples and
-          specimens.
+        description:
+          A persistent unique identifier for physical samples and specimens.
         see_also:
           - https://www.igsn.org/
       ISBN:
-        description: >-
-          International Standard Book Number. A unique numeric book
-          identifier.
+        description:
+          International Standard Book Number. A unique numeric book identifier.
       ISSN:
-        description: >-
-          International Standard Serial Number. A unique 8-digit number
-          used to identify a print or electronic periodical publication.
+        description:
+          International Standard Serial Number. A unique 8-digit number used to
+          identify a print or electronic periodical publication.
       ISTC:
-        description: >-
-          International Standard text Code. A unique “number” assgned to
-          a textual work. An ISTC consists of 16 numbers and/or letters.
+        description:
+          International Standard text Code. A unique “number” assgned to a
+          textual work. An ISTC consists of 16 numbers and/or letters.
       LISSN:
-        description: >-
-          The Linking ISSN or ISSN-L enables collocation or linking
-          among different media versions of a continuing resource.
+        description:
+          The Linking ISSN or ISSN-L enables collocation or linking among
+          different media versions of a continuing resource.
       PMID:
-        description: >-
-          PubMed identifier. A unique number assigned to each PubMed
-          record.
+        description:
+          PubMed identifier. A unique number assigned to each PubMed record.
       PURL:
-        description: >-
-          Permanent Uniform Resource Locator.
+        description: Permanent Uniform Resource Locator.
       RAiD:
-        description: >-
-          Research Activity Identifier.
+        description: Research Activity Identifier.
         see_also:
           - https://www.raid.org.au/
       RRID:
-        description: >-
-          Research Resource Identifier.
+        description: Research Resource Identifier.
         see_also:
           - https://www.rrids.org/
       SWHID:
-        description: >-
-          SoftWare Hash IDentifiers are persistent, intrinsic
-          identifiers for software source code artifacts such as source
-          code files, source trees, commits, and other objects typically
-          found in version control systems.
+        description:
+          SoftWare Hash IDentifiers are persistent, intrinsic identifiers for
+          software source code artifacts such as source code files, source
+          trees, commits, and other objects typically found in version control
+          systems.
       UPC:
-        description: >-
-          Universal Product Code is a barcode symbology used for
-          tracking trade idems in store.
+        description:
+          Universal Product Code is a barcode symbology used for tracking trade
+          idems in store.
       URL:
-        description: >-
-          Uniform Resource Locator, also known as web address.
+        description: Uniform Resource Locator, also known as web address.
       URN:
-        description: >-
-          Uniform Resource Name. A unique and persistent identifier of
-          an electronic document.
+        description:
+          Uniform Resource Name. A unique and persistent identifier of an
+          electronic document.
       w3id:
-        description: >-
-          Permanent identifier for Web applications. Mostly used to
-          publish vocabularies and ontologies.
+        description:
+          Permanent identifier for Web applications. Mostly used to publish
+          vocabularies and ontologies.
 
   PIDInstRelationType:
-    description: >-
-      Possible types of relation between a PIDInst instance and its
-      related identifiers.
+    description:
+      Possible types of relation between a PIDInst instance and its related
+      identifiers.
     permissible_values:
       IsDescribedBy:
-        description: >-
-          The lined resource is a document describing the instrument.
+        description: The lined resource is a document describing the instrument.
       IsNewVersionOf:
-        description: >-
+        description:
           If an instrument is substantially modified, a new PID may be
-          attributed to the new version. In that case the old and the
-          new PID should be linked to each other. `IsNewVersionOf`
-          should be used in the new PID record to link the old
-          instrument before the modification.
+          attributed to the new version. In that case the old and the new PID
+          should be linked to each other. `IsNewVersionOf` should be used in the
+          new PID record to link the old instrument before the modification.
       IsPreviousVersionOf:
-        description: >-
+        description:
           If an instrument is substantially modified, a new PID may be
-          attributed to the new version. In that case the old and the
-          new PID should be linked to each other. `IsPreviousVersionOf`
-          should be used in the old PID record to link the new
-          instrument after the modification.
+          attributed to the new version. In that case the old and the new PID
+          should be linked to each other. `IsPreviousVersionOf` should be used
+          in the old PID record to link the new instrument after the
+          modification.
       HasComponent:
-        description: >-
-          In the case of a complex instrument, having multiple
-          components that may be considered as instruments in their own
-          right, with their own PIDs, these PIDs should be linked.
-          `HasComponent` should be used in the PID record of the
-          compound instrument to link the components.
+        description:
+          In the case of a complex instrument, having multiple components that
+          may be considered as instruments in their own right, with their own
+          PIDs, these PIDs should be linked. `HasComponent` should be used in
+          the PID record of the compound instrument to link the components.
       IsComponentOf:
-        description: >-
-          In the case of a complex instrument, having multiple
-          components that may be considered as instruments in their own
-          right, with their own PIDs, these PIDs should be linked.
-          `IsComponentOf` should be used in the PID records of the
-          components to link the compound instrument.
+        description:
+          In the case of a complex instrument, having multiple components that
+          may be considered as instruments in their own right, with their own
+          PIDs, these PIDs should be linked. `IsComponentOf` should be used in
+          the PID records of the components to link the compound instrument.
       References:
-        description: >-
-          This may be used in the generic case, if no other more
-          specific relation type applies.
+        description:
+          This may be used in the generic case, if no other more specific
+          relation type applies.
       HasMetadata:
-        description: >-
-          If there is additional metadata describing the instrument,
-          possibly using a community specific metadata standard, that
-          metadata record may be linked using `HasMetadata`.
+        description:
+          If there is additional metadata describing the instrument, possibly
+          using a community specific metadata standard, that metadata record may
+          be linked using `HasMetadata`.
       WasUsedIn:
-        description: >-
-          If the instrument has been deployed in some research activity,
-          such as a cruise of a research vessel, `WasUsedIn` may be used
-          to link that activity.
+        description:
+          If the instrument has been deployed in some research activity, such as
+          a cruise of a research vessel, `WasUsedIn` may be used to link that
+          activity.
       IsIdenticalTo:
-        description: >-
-          If multiple PIDs have been attributed to a single instrument
-          (which should preferably be avoided in the first place), these
-          PID records should be linked to each other using
-          `IsIdenticalTo`.
+        description:
+          If multiple PIDs have been attributed to a single instrument (which
+          should preferably be avoided in the first place), these PID records
+          should be linked to each other using `IsIdenticalTo`.
       IsAttachedTo:
-        description: >-
-          If the instrument is permanently attached to another
-          instrument, the PID record for both instruments should link to
-          each other using `IsAttachedTo`.
+        description:
+          If the instrument is permanently attached to another instrument, the
+          PID record for both instruments should link to each other using
+          `IsAttachedTo`.
 
   PIDInstAlternateIdentifierType:
-    description: >-
-      Possible types of alternate identifiers for a PIDINST instance.
+    description: Possible types of alternate identifiers for a PIDINST instance.
     permissible_values:
       SerialNumber:
-        description: >-
-          A serial number attributed by the manufacturer.
+        description: A serial number attributed by the manufacturer.
       InventoryNumber:
-        description: >-
-          An inventory number used by the owner.
+        description: An inventory number used by the owner.
       Other:
-        description: >-
-          Any other kind of identifier.
+        description: Any other kind of identifier.


### PR DESCRIPTION
As discussed during the July 1st meeting, this PR adds a possible representation of the PIDINST 1.1 model as a LinkML schema, along with a sample JSON file that follows the serialisation defined by that schema.